### PR TITLE
feat: Implement lesson management feature for teachers

### DIFF
--- a/_sql_updates.txt
+++ b/_sql_updates.txt
@@ -1,0 +1,11 @@
+-- SQL update for the lessons feature
+
+CREATE TABLE `lessons` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) NOT NULL,
+  `content` text NOT NULL,
+  `tags` text,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/dashboard.php
+++ b/dashboard.php
@@ -56,14 +56,17 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
                 </div>
 
                 <div class="row">
+                    <?php if ($_SESSION['role'] === 'teacher'): ?>
                     <div class="col-md-6">
                         <div class="card mb-4">
-                            <div class="card-header">Funzionalità Futura 1</div>
-                            <div class="card-body feature-slot">
-                                <p class="text-muted">_slot per implementazione futura_</p>
+                            <div class="card-header">Gestisci Lezioni</div>
+                            <div class="card-body feature-slot d-flex flex-column justify-content-center align-items-center">
+                                <p>Crea, modifica e visualizza le lezioni.</p>
+                                <a href="lessons/index.php" class="btn btn-primary">Vai a Lezioni</a>
                             </div>
                         </div>
                     </div>
+                    <?php endif; ?>
                     <div class="col-md-6">
                         <div class="card mb-4">
                             <div class="card-header">Funzionalità Futura 2</div>

--- a/lesson_example.json
+++ b/lesson_example.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Lezione di Esempio 1: Introduzione alla Wikitext",
+    "content": "Benvenuti alla prima lezione.\n\nQuesto è un paragrafo.\n\n'''Testo in grassetto'''\n''Testo in corsivo''\n\n== Sottotitolo ==\nEcco un elenco puntato:\n* Primo punto\n* Secondo punto\n\n----\n\nLink esterno: [https://www.wikipedia.org Wikipedia]\nLink interno: [[Lezione di Esempio 2]]",
+    "tags": "introduzione, wikitext, esempio"
+  },
+  {
+    "title": "Lezione di Esempio 2: Argomenti Avanzati",
+    "content": "Questa è la seconda lezione che approfondisce gli argomenti.\n\n=== Un'altra intestazione ===\nIl contenuto di questa lezione è ancora in fase di definizione.",
+    "tags": "avanzato, wikitext"
+  }
+]

--- a/lessons/delete.php
+++ b/lessons/delete.php
@@ -1,0 +1,20 @@
+<?php
+session_start();
+// Auth check
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION["role"] !== 'teacher') {
+    header("location: ../login.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+
+// Check if an ID was provided
+if (isset($_GET['id']) && !empty($_GET['id'])) {
+    Lesson::delete((int)$_GET['id']);
+}
+
+// Redirect back to the lesson list
+header("location: index.php");
+exit;
+?>

--- a/lessons/edit.php
+++ b/lessons/edit.php
@@ -1,0 +1,135 @@
+<?php
+session_start();
+// Auth check
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION["role"] !== 'teacher') {
+    header("location: ../login.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+
+$lesson = null;
+$pageTitle = 'Aggiungi Nuova Lezione';
+$formAction = 'save.php';
+
+// Check if we are editing an existing lesson
+if (isset($_GET['id']) && !empty($_GET['id'])) {
+    $lesson = Lesson::findById((int)$_GET['id']);
+    if ($lesson) {
+        $pageTitle = 'Modifica Lezione';
+    } else {
+        // Lesson not found, maybe show an error or redirect
+        header("location: index.php");
+        exit;
+    }
+}
+
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo $pageTitle; ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="../dashboard.php">Gestionale Studio</a>
+            <div class="collapse navbar-collapse">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="../logout.php">Logout</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <h1 class="h2 mb-4"><?php echo $pageTitle; ?></h1>
+
+        <div class="card">
+            <div class="card-body">
+                <form action="<?php echo $formAction; ?>" method="post">
+                    <?php if ($lesson && $lesson->id): ?>
+                        <input type="hidden" name="id" value="<?php echo $lesson->id; ?>">
+                    <?php endif; ?>
+
+                    <div class="mb-3">
+                        <label for="title" class="form-label">Titolo</label>
+                        <input type="text" class="form-control" id="title" name="title" value="<?php echo htmlspecialchars($lesson->title ?? ''); ?>" required>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="tags" class="form-label">Tags (separati da virgola)</label>
+                        <input type="text" class="form-control" id="tags" name="tags" value="<?php echo htmlspecialchars($lesson->tags ?? ''); ?>">
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="content" class="form-label">Contenuto (Wikitext)</label>
+                        <div id="wikitext-toolbar" class="btn-toolbar mb-2" role="toolbar">
+                            <div class="btn-group btn-group-sm me-2">
+                                <button type="button" class="btn btn-outline-secondary" onclick="wrapText('bold')"><b>B</b></button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="wrapText('italic')"><i>I</i></button>
+                            </div>
+                            <div class="btn-group btn-group-sm">
+                                <button type="button" class="btn btn-outline-secondary" onclick="wrapText('internal-link')">Link Interno</button>
+                                <button type="button" class="btn btn-outline-secondary" onclick="wrapText('external-link')">Link Esterno</button>
+                            </div>
+                        </div>
+                        <textarea class="form-control" id="content" name="content" rows="15" required><?php echo htmlspecialchars($lesson->content ?? ''); ?></textarea>
+                    </div>
+
+                    <a href="index.php" class="btn btn-secondary">Annulla</a>
+                    <button type="submit" class="btn btn-primary">Salva Lezione</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        function wrapText(style) {
+            const textarea = document.getElementById('content');
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const selectedText = textarea.value.substring(start, end);
+            let replacement = selectedText;
+
+            switch (style) {
+                case 'bold':
+                    replacement = "'''" + selectedText + "'''";
+                    break;
+                case 'italic':
+                    replacement = "''" + selectedText + "''";
+                    break;
+                case 'internal-link':
+                    replacement = "[[" + (selectedText || 'Titolo Pagina') + "]]";
+                    break;
+                case 'external-link':
+                    replacement = "[" + (selectedText || 'https://example.com') + " Testo del link]";
+                    break;
+            }
+
+            textarea.setRangeText(replacement, start, end);
+            textarea.focus();
+
+            // Move cursor to a logical position after insertion
+            if (selectedText) {
+                 textarea.selectionStart = textarea.selectionEnd = start + replacement.length;
+            } else {
+                if(style === 'internal-link') {
+                    textarea.selectionStart = start + 2;
+                    textarea.selectionEnd = start + 2 + 'Titolo Pagina'.length;
+                } else if (style === 'external-link') {
+                     textarea.selectionStart = start + 1;
+                     textarea.selectionEnd = start + 1 + 'https://example.com'.length;
+                }
+            }
+        }
+    </script>
+</body>
+</html>

--- a/lessons/import.php
+++ b/lessons/import.php
@@ -1,0 +1,39 @@
+<?php
+session_start();
+// Auth check
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION["role"] !== 'teacher') {
+    header("location: ../login.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+
+if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_FILES["jsonFile"])) {
+    $file = $_FILES["jsonFile"];
+
+    // Check for errors and validate file type
+    if ($file["error"] == 0 && $file["type"] == "application/json") {
+        $content = file_get_contents($file["tmp_name"]);
+        $lessonsData = json_decode($content, true);
+
+        if (json_last_error() === JSON_ERROR_NONE && is_array($lessonsData)) {
+            foreach ($lessonsData as $lessonData) {
+                // Basic validation for each lesson object
+                if (isset($lessonData['title']) && isset($lessonData['content'])) {
+                    $lesson = new Lesson([
+                        'title' => $lessonData['title'],
+                        'content' => $lessonData['content'],
+                        'tags' => $lessonData['tags'] ?? ''
+                    ]);
+                    $lesson->save();
+                }
+            }
+        }
+    }
+}
+
+// Redirect back to the lesson list
+header("location: index.php");
+exit;
+?>

--- a/lessons/index.php
+++ b/lessons/index.php
@@ -1,0 +1,172 @@
+<?php
+session_start();
+// Redirect to login if not logged in
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
+    header("location: ../login.php");
+    exit;
+}
+// Redirect to dashboard if not a teacher
+if ($_SESSION["role"] !== 'teacher') {
+    header("location: ../dashboard.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+
+// Pagination settings
+$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+$page = max(1, $page);
+$limit = 10; // 10 lessons per page
+$offset = ($page - 1) * $limit;
+
+// Search terms
+$search_content = trim($_GET['search_content'] ?? '');
+$search_tags = trim($_GET['search_tags'] ?? '');
+$is_search = !empty($search_content) || !empty($search_tags);
+
+if ($is_search) {
+    $total_lessons = Lesson::countSearch($search_content, $search_tags);
+    $lessons = Lesson::search($search_content, $search_tags, $limit, $offset);
+} else {
+    $total_lessons = Lesson::countAll();
+    $lessons = Lesson::findAll($limit, $offset);
+}
+
+$total_pages = ceil($total_lessons / $limit);
+
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gestisci Lezioni</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="../dashboard.php">Gestionale Studio</a>
+            <div class="collapse navbar-collapse">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="../logout.php">Logout</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h2">Gestione Lezioni</h1>
+            <a href="edit.php" class="btn btn-primary">Aggiungi Nuova Lezione</a>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">Cerca Lezioni & Importa</div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <h5>Cerca Lezioni</h5>
+                        <form action="index.php" method="get" class="row g-3">
+                            <div class="col-12">
+                                <label for="search_content" class="form-label">Contenuto</label>
+                                <input type="text" class="form-control" id="search_content" name="search_content" value="<?php echo htmlspecialchars($search_content); ?>">
+                            </div>
+                            <div class="col-12">
+                                <label for="search_tags" class="form-label">Tags</label>
+                                <input type="text" class="form-control" id="search_tags" name="search_tags" value="<?php echo htmlspecialchars($search_tags); ?>">
+                            </div>
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-info">Cerca</button>
+                                <a href="index.php" class="btn btn-secondary">Reset</a>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="col-md-6">
+                        <h5>Importa da JSON</h5>
+                        <form action="import.php" method="post" enctype="multipart/form-data">
+                            <div class="mb-3">
+                                <label for="jsonFile" class="form-label">Seleziona file JSON</label>
+                                <input class="form-control" type="file" id="jsonFile" name="jsonFile" accept="application/json" required>
+                            </div>
+                            <button type="submit" class="btn btn-success">Carica File</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                Elenco Lezioni (Pagina <?php echo $page; ?> di <?php echo $total_pages; ?>)
+            </div>
+            <div class="card-body">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th scope="col">Titolo</th>
+                            <th scope="col">Tags</th>
+                            <th scope="col">Azioni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (empty($lessons)): ?>
+                            <tr>
+                                <td colspan="3" class="text-center">Nessuna lezione trovata.</td>
+                            </tr>
+                        <?php else: ?>
+                            <?php foreach ($lessons as $lesson): ?>
+                                <tr>
+                                    <td><?php echo htmlspecialchars($lesson->title); ?></td>
+                                    <td><?php echo htmlspecialchars($lesson->tags); ?></td>
+                                    <td>
+                                        <a href="view.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-info">Visualizza</a>
+                                        <a href="edit.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-warning">Modifica</a>
+                                        <a href="delete.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-danger">Cancella</a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+            <?php if ($total_pages > 1): ?>
+            <div class="card-footer">
+                <nav aria-label="Navigazione pagine">
+                    <ul class="pagination justify-content-center">
+                        <?php
+                        // Build query string for pagination links
+                        $queryString = '';
+                        if ($is_search) {
+                            $queryString = http_build_query([
+                                'search_content' => $search_content,
+                                'search_tags' => $search_tags
+                            ]);
+                        }
+                        ?>
+                        <li class="page-item <?php echo ($page <= 1) ? 'disabled' : ''; ?>">
+                            <a class="page-link" href="?page=<?php echo $page - 1; ?>&<?php echo $queryString; ?>">Precedente</a>
+                        </li>
+
+                        <?php for ($i = 1; $i <= $total_pages; $i++): ?>
+                        <li class="page-item <?php echo ($i == $page) ? 'active' : ''; ?>">
+                            <a class="page-link" href="?page=<?php echo $i; ?>&<?php echo $queryString; ?>"><?php echo $i; ?></a>
+                        </li>
+                        <?php endfor; ?>
+
+                        <li class="page-item <?php echo ($page >= $total_pages) ? 'disabled' : ''; ?>">
+                            <a class="page-link" href="?page=<?php echo $page + 1; ?>&<?php echo $queryString; ?>">Successiva</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/lessons/save.php
+++ b/lessons/save.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+// Auth check
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION["role"] !== 'teacher') {
+    header("location: ../login.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+
+// Check if the form was submitted
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Basic validation
+    if (isset($_POST['title']) && isset($_POST['content'])) {
+
+        $data = [
+            'id' => isset($_POST['id']) && !empty($_POST['id']) ? (int)$_POST['id'] : null,
+            'title' => trim($_POST['title']),
+            'content' => trim($_POST['content']),
+            'tags' => isset($_POST['tags']) ? trim($_POST['tags']) : ''
+        ];
+
+        $lesson = new Lesson($data);
+        $lesson->save();
+    }
+}
+
+// Redirect back to the lesson list
+header("location: index.php");
+exit;
+?>

--- a/lessons/view.php
+++ b/lessons/view.php
@@ -1,0 +1,94 @@
+<?php
+session_start();
+// Auth check
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION["role"] !== 'teacher') {
+    header("location: ../login.php");
+    exit;
+}
+
+require_once '../src/Database.php';
+require_once '../src/Lesson.php';
+require_once '../src/wikitext_parser.php';
+
+$lesson = null;
+if (isset($_GET['id'])) {
+    $lesson = Lesson::findById((int)$_GET['id']);
+} elseif (isset($_GET['title'])) {
+    $lesson = Lesson::findByTitle(urldecode($_GET['title']));
+}
+
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo $lesson ? htmlspecialchars($lesson->title) : 'Lezione non trovata'; ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .wikitext-content h2 {
+            border-bottom: 1px solid #dee2e6;
+            padding-bottom: .5rem;
+            margin-top: 1.5rem;
+        }
+        .wikitext-content h3 {
+            margin-top: 1rem;
+        }
+        .wikitext-content p {
+            line-height: 1.6;
+        }
+        .wikitext-content hr {
+            margin: 2rem 0;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="../dashboard.php">Gestionale Studio</a>
+            <div class="collapse navbar-collapse">
+                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <a class="nav-link" href="index.php">Torna a Elenco Lezioni</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="../logout.php">Logout</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <?php if ($lesson): ?>
+            <div class="card">
+                <div class="card-header">
+                    <h1 class="h2 mb-0"><?php echo htmlspecialchars($lesson->title); ?></h1>
+                    <?php if (!empty($lesson->tags)): ?>
+                        <small class="text-muted">Tags: <?php echo htmlspecialchars($lesson->tags); ?></small>
+                    <?php endif; ?>
+                </div>
+                <div class="card-body">
+                    <div class="wikitext-content">
+                        <?php echo parse_wikitext($lesson->content); ?>
+                    </div>
+                </div>
+                <div class="card-footer">
+                     <a href="edit.php?id=<?php echo $lesson->id; ?>" class="btn btn-primary">Modifica Lezione</a>
+                </div>
+            </div>
+        <?php else: ?>
+            <div class="alert alert-danger" role="alert">
+                <h4 class="alert-heading">Errore</h4>
+                <p>La lezione richiesta non è stata trovata.</p>
+                <hr>
+                <a href="index.php" class="btn btn-secondary">Torna all'elenco</a>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/Lesson.php
+++ b/src/Lesson.php
@@ -1,0 +1,223 @@
+<?php
+
+class Lesson
+{
+    public $id;
+    public $title;
+    public $content;
+    public $tags;
+    public $created_at;
+    public $updated_at;
+
+    public function __construct($data)
+    {
+        $this->id = $data['id'] ?? null;
+        $this->title = $data['title'] ?? '';
+        $this->content = $data['content'] ?? '';
+        $this->tags = $data['tags'] ?? '';
+        $this->created_at = $data['created_at'] ?? null;
+        $this->updated_at = $data['updated_at'] ?? null;
+    }
+
+    /**
+     * Find all lessons with pagination.
+     *
+     * @param int $limit
+     * @param int $offset
+     * @return Lesson[]
+     */
+    public static function findAll($limit, $offset)
+    {
+        $pdo = Database::getInstance();
+        $stmt = $pdo->prepare('SELECT * FROM lessons ORDER BY updated_at DESC LIMIT :limit OFFSET :offset');
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $lessonsData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $lessons = [];
+        foreach ($lessonsData as $data) {
+            $lessons[] = new self($data);
+        }
+        return $lessons;
+    }
+
+    /**
+     * Count all lessons.
+     * @return int
+     */
+    public static function countAll()
+    {
+        $pdo = Database::getInstance();
+        return (int) $pdo->query('SELECT COUNT(id) FROM lessons')->fetchColumn();
+    }
+
+    /**
+     * Find a single lesson by its ID.
+     *
+     * @param int $id
+     * @return Lesson|null
+     */
+    public static function findById($id)
+    {
+        $pdo = Database::getInstance();
+        $stmt = $pdo->prepare('SELECT * FROM lessons WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($data) {
+            return new self($data);
+        }
+        return null;
+    }
+
+    /**
+     * Find a single lesson by its exact title.
+     *
+     * @param string $title
+     * @return Lesson|null
+     */
+    public static function findByTitle($title)
+    {
+        $pdo = Database::getInstance();
+        $stmt = $pdo->prepare('SELECT * FROM lessons WHERE title = :title');
+        $stmt->execute(['title' => $title]);
+        $data = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($data) {
+            return new self($data);
+        }
+        return null;
+    }
+
+    /**
+     * Save the lesson (insert or update).
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        $pdo = Database::getInstance();
+
+        if ($this->id) {
+            // Update existing lesson
+            $stmt = $pdo->prepare(
+                'UPDATE lessons SET title = :title, content = :content, tags = :tags WHERE id = :id'
+            );
+            return $stmt->execute([
+                'id' => $this->id,
+                'title' => $this->title,
+                'content' => $this->content,
+                'tags' => $this->tags,
+            ]);
+        } else {
+            // Insert new lesson
+            $stmt = $pdo->prepare(
+                'INSERT INTO lessons (title, content, tags) VALUES (:title, :content, :tags)'
+            );
+            $result = $stmt->execute([
+                'title' => $this->title,
+                'content' => $this->content,
+                'tags' => $this->tags,
+            ]);
+            if ($result) {
+                $this->id = $pdo->lastInsertId();
+            }
+            return $result;
+        }
+    }
+
+    /**
+     * Delete a lesson by its ID.
+     *
+     * @param int $id
+     * @return bool
+     */
+    public static function delete($id)
+    {
+        $pdo = Database::getInstance();
+        $stmt = $pdo->prepare('DELETE FROM lessons WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+
+    /**
+     * Search for lessons by content and tags with pagination.
+     *
+     * @param string $contentTerm
+     * @param string $tagsTerm
+     * @param int $limit
+     * @param int $offset
+     * @return Lesson[]
+     */
+    public static function search($contentTerm, $tagsTerm, $limit, $offset)
+    {
+        $pdo = Database::getInstance();
+        list($sql, $params) = self::buildSearchQuery('SELECT *', $contentTerm, $tagsTerm);
+
+        $sql .= ' ORDER BY updated_at DESC LIMIT :limit OFFSET :offset';
+        $params[':limit'] = $limit;
+        $params[':offset'] = $offset;
+
+        $stmt = $pdo->prepare($sql);
+
+        // Bind parameters dynamically
+        foreach ($params as $key => &$val) {
+            $type = is_int($val) ? PDO::PARAM_INT : PDO::PARAM_STR;
+            $stmt->bindParam($key, $val, $type);
+        }
+
+        $stmt->execute();
+
+        $lessonsData = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $lessons = [];
+        foreach ($lessonsData as $data) {
+            $lessons[] = new self($data);
+        }
+        return $lessons;
+    }
+
+    /**
+     * Count search results.
+     *
+     * @param string $contentTerm
+     * @param string $tagsTerm
+     * @return int
+     */
+    public static function countSearch($contentTerm, $tagsTerm)
+    {
+        $pdo = Database::getInstance();
+        list($sql, $params) = self::buildSearchQuery('SELECT COUNT(id)', $contentTerm, $tagsTerm);
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Helper to build the search query.
+     */
+    private static function buildSearchQuery($select, $contentTerm, $tagsTerm)
+    {
+        $sql = $select . ' FROM lessons';
+        $where = [];
+        $params = [];
+
+        if (!empty($contentTerm)) {
+            $where[] = 'content LIKE :content';
+            $params[':content'] = '%' . $contentTerm . '%';
+        }
+
+        if (!empty($tagsTerm)) {
+            $where[] = 'tags LIKE :tags';
+            $params[':tags'] = '%' . $tagsTerm . '%';
+        }
+
+        if (!empty($where)) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+
+        return [$sql, $params];
+    }
+}

--- a/src/wikitext_parser.php
+++ b/src/wikitext_parser.php
@@ -1,0 +1,51 @@
+<?php
+
+function parse_wikitext($text) {
+    // 1. Escape HTML to prevent XSS
+    $text = htmlspecialchars($text);
+
+    // 2. Bold: '''text''' -> <strong>text</strong>
+    $text = preg_replace("/'''(.*?)'''/", '<strong>$1</strong>', $text);
+
+    // 3. Italic: ''text'' -> <em>text</em>
+    $text = preg_replace("/''(.*?)''/", '<em>$1</em>', $text);
+
+    // 4. Internal Links: [[Page Title]] -> <a href="view.php?title=Page+Title">Page Title</a>
+    // This regex handles [[Page Title|Display Text]] as well
+    $text = preg_replace_callback(
+        '/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/',
+        function ($matches) {
+            $page = trim($matches[1]);
+            $display = isset($matches[2]) ? trim($matches[2]) : $page;
+            // Note: This assumes a URL structure based on title. We are using ID.
+            // This rule may need to be adjusted later to link by ID if titles aren't unique.
+            // For now, this is a good placeholder.
+            $url = 'view.php?title=' . urlencode($page);
+            return '<a href="' . $url . '">' . htmlspecialchars($display) . '</a>';
+        },
+        $text
+    );
+
+    // 5. External Links: [http://example.com Display Text]
+    $text = preg_replace(
+        '/\[(https?:\/\/[^\s\]]+)\s+([^\]]+)\]/',
+        '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>',
+        $text
+    );
+
+    // 6. Headings: ==Heading== -> <h2>Heading</h2>
+    $text = preg_replace('/^==\s*(.*?)\s*==/m', '<h2>$1</h2>', $text);
+    $text = preg_replace('/^===\s*(.*?)\s*===/m', '<h3>$1</h3>', $text);
+
+
+    // 7. Horizontal Rule: ----
+    $text = preg_replace('/^----/m', '<hr>', $text);
+
+    // 8. Paragraphs: Convert double newlines to paragraphs
+    $text = '<p>' . preg_replace('/\n\s*\n/', '</p><p>', $text) . '</p>';
+
+    // Cleanup empty paragraphs
+    $text = preg_replace('/<p><\/p>/', '', $text);
+
+    return $text;
+}


### PR DESCRIPTION
This commit introduces a new 'Manage Lessons' feature, accessible only to users with the 'teacher' role.

The feature includes a comprehensive interface for creating, reading, updating, and deleting lessons. Key functionalities are:
- A new section on the dashboard for teachers to access the feature.
- A lesson list with search (by content and tags) and pagination.
- A wikitext editor with a simple toolbar for formatting assistance.
- A custom wikitext parser to render lesson content as HTML for viewing.
- Functionality to import lessons from a JSON file.
- All new pages are protected and restricted to the 'teacher' role.