### PR TITLE
feat: Add feedback system for JSON import

### DIFF
--- a/lessons/import.php
+++ b/lessons/import.php
@@ -9,28 +9,63 @@ if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true || $_SESSION
 require_once '../src/Database.php';
 require_once '../src/Lesson.php';
 
+// Default feedback
+$_SESSION['import_feedback'] = ['type' => 'danger', 'message' => 'Si è verificato un errore sconosciuto.'];
+
 if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_FILES["jsonFile"])) {
     $file = $_FILES["jsonFile"];
 
-    // Check for errors and validate file type
-    if ($file["error"] == 0) {
-        $content = file_get_contents($file["tmp_name"]);
-        $lessonsData = json_decode($content, true);
+    // Check for upload errors
+    if ($file["error"] !== UPLOAD_ERR_OK) {
+        $_SESSION['import_feedback'] = ['type' => 'danger', 'message' => 'Errore durante il caricamento del file. Codice: ' . $file["error"]];
+        header("location: index.php");
+        exit;
+    }
 
-        if (json_last_error() === JSON_ERROR_NONE && is_array($lessonsData)) {
-            foreach ($lessonsData as $lessonData) {
-                // Basic validation for each lesson object
-                if (isset($lessonData['title']) && isset($lessonData['content'])) {
-                    $lesson = new Lesson([
-                        'title' => $lessonData['title'],
-                        'content' => $lessonData['content'],
-                        'tags' => $lessonData['tags'] ?? ''
-                    ]);
-                    $lesson->save();
+    $content = file_get_contents($file["tmp_name"]);
+    $lessonsData = json_decode($content, true);
+
+    // Check for JSON errors
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        $_SESSION['import_feedback'] = ['type' => 'danger', 'message' => 'Errore di parsing del JSON: ' . json_last_error_msg()];
+        header("location: index.php");
+        exit;
+    }
+
+    if (is_array($lessonsData)) {
+        $success_count = 0;
+        $failure_count = 0;
+
+        foreach ($lessonsData as $lessonData) {
+            if (isset($lessonData['title']) && isset($lessonData['content'])) {
+                $lesson = new Lesson([
+                    'title' => $lessonData['title'],
+                    'content' => $lessonData['content'],
+                    'tags' => $lessonData['tags'] ?? ''
+                ]);
+
+                if ($lesson->save()) {
+                    $success_count++;
+                } else {
+                    $failure_count++;
                 }
+            } else {
+                $failure_count++;
             }
         }
+
+        $message = "Importazione completata. Lezioni aggiunte con successo: $success_count.";
+        if ($failure_count > 0) {
+            $message .= " Lezioni non riuscite: $failure_count.";
+            $_SESSION['import_feedback'] = ['type' => 'warning', 'message' => $message];
+        } else {
+            $_SESSION['import_feedback'] = ['type' => 'success', 'message' => $message];
+        }
+
+    } else {
+        $_SESSION['import_feedback'] = ['type' => 'danger', 'message' => 'Il file JSON non contiene un array di lezioni valido.'];
     }
+
 }
 
 // Redirect back to the lesson list

--- a/lessons/index.php
+++ b/lessons/index.php
@@ -59,6 +59,16 @@ $total_pages = ceil($total_lessons / $limit);
     </nav>
 
     <div class="container mt-4">
+        <?php
+        if (isset($_SESSION['import_feedback'])) {
+            $feedback = $_SESSION['import_feedback'];
+            echo '<div class="alert alert-' . htmlspecialchars($feedback['type']) . ' alert-dismissible fade show" role="alert">';
+            echo htmlspecialchars($feedback['message']);
+            echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>';
+            echo '</div>';
+            unset($_SESSION['import_feedback']);
+        }
+        ?>
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="h2">Gestione Lezioni</h1>
             <a href="edit.php" class="btn btn-primary">Aggiungi Nuova Lezione</a>


### PR DESCRIPTION
This commit enhances the JSON import feature by adding a detailed feedback system.

- `lessons/import.php` now captures specific outcomes of the import process, including file upload errors, JSON parsing errors, and the number of successful or failed database insertions.
- A status message (success, warning, or danger) is stored in a session variable.
- `lessons/index.php` now displays the feedback message from the session in an alert box, making the import process transparent to the user.

This will help diagnose any future issues with the import functionality and improves the overall user experience.