### PR TITLE
Feat: Enhance wikitext parser with nested lists and advanced image op…

### DIFF
--- a/lessons/view.php
+++ b/lessons/view.php
@@ -88,6 +88,15 @@ if ($lesson && isset($_SESSION['id']) && $_SESSION['role'] === 'student') {
             padding: .1rem;
             border: none;
         }
+        .figure-thumbnail {
+            border: 1px solid #dee2e6;
+            background-color: #f8f9fa;
+            padding: 0.5rem;
+            margin-bottom: 1rem;
+        }
+        .figure-wrapper.mx-auto {
+            clear: both;
+        }
     </style>
 </head>
 <body>

--- a/src/wikitext_parser.php
+++ b/src/wikitext_parser.php
@@ -1,5 +1,38 @@
 <?php
 
+function parse_inline_wikitext($text) {
+    // This function assumes the text has already been through htmlspecialchars.
+
+    // Bold and Italic
+    $text = preg_replace("/'''(.*?)'''/", '<strong>$1</strong>', $text);
+    $text = preg_replace("/''(.*?)''/", '<em>$1</em>', $text);
+
+    // Colored Text
+    $text = preg_replace_callback('/\{\{color:([a-zA-Z]+|#[0-9a-fA-F]{3,6})\|(.*?)\}\}/', function ($matches) {
+        $color = htmlspecialchars_decode($matches[1]);
+        $content = $matches[2];
+        if (!preg_match('/^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,6})$/', $color)) {
+            return $matches[0]; // Invalid color
+        }
+        return '<span style="color:' . $color . ';">' . $content . '</span>';
+    }, $text);
+
+    // Links (Internal and External)
+    // Exclude [[Image...]] and [[Video...]]
+    $text = preg_replace_callback('/\[\[([^\]|:\n]+)(?:\|([^\]\n]+))?\]\]/', function ($matches) {
+        $page = trim($matches[1]);
+        $display = isset($matches[2]) ? trim($matches[2]) : $page;
+        $url = 'view.php?title=' . urlencode($page);
+        // The display text is already escaped from the initial call in parse_wikitext
+        return '<a href="' . $url . '">' . $display . '</a>';
+    }, $text);
+
+    $text = preg_replace('/\[(https?:\/\/[^\s\]]+)\s+([^\]]+)\]/', '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>', $text);
+
+    return $text;
+}
+
+
 function parse_wikitext($text) {
     // The order of operations is important.
 
@@ -29,21 +62,82 @@ function parse_wikitext($text) {
     $text = preg_replace('/^----/m', '<hr>', $text);
 
     // 4. Lists (Bulleted and Numbered)
-    $text = preg_replace_callback('/((?:(?:^\*|\#)\s.*(?:\n|$))+)/m', function ($matches) use ($make_placeholder) {
-        $list_text = trim($matches[1]);
+    $text = preg_replace_callback('/((?:(?:^[*#]+)\s.*(?:\n|$))+)/m', function ($matches) use ($make_placeholder) {
+        $list_text = trim($matches[0]);
         $lines = explode("\n", $list_text);
-        $type = (strpos($lines[0], '*') === 0) ? 'ul' : 'ol';
 
-        $items_html = '';
+        // --- Tree-based parser for nested lists ---
+
+        // 1. Build a tree from the list lines
+        $list_tree = [];
+        $path = []; // A stack of indices to the current node
+
         foreach ($lines as $line) {
-            $line = trim($line);
-            if(empty($line)) continue;
-            // Remove the marker (* or #) and trim
-            $item_content = trim(substr($line, 1));
-            $items_html .= '<li>' . $item_content . '</li>';
+            if (trim($line) === '') continue;
+
+            preg_match('/^([*#]+)\s*(.*)/', $line, $item_matches);
+            if (!$item_matches) continue;
+
+            $markers = $item_matches[1];
+            $content = $item_matches[2];
+            $level = strlen($markers);
+            $type = ($markers[0] === '*') ? 'ul' : 'ol';
+
+            // Adjust path to find the correct parent
+            while (count($path) >= $level) {
+                array_pop($path);
+            }
+
+            // Traverse to the parent node
+            $parent = &$list_tree;
+            foreach ($path as $index) {
+                $parent = &$parent[count($parent) - 1]['children'];
+            }
+
+            // Add the new item
+            $parent[] = ['type' => $type, 'content' => $content, 'children' => []];
+
+            // Update the path to point to the new item
+            $path[] = count($parent) - 1;
         }
 
-        $list_html = "<{$type}>" . $items_html . "</{$type}>";
+        // 2. Render the tree into HTML
+        $render_list_tree = function($tree) use (&$render_list_tree) {
+            if (empty($tree)) {
+                return '';
+            }
+
+            $html = '';
+            $current_list_type = null;
+            $buffer = [];
+
+            $flush_buffer = function() use (&$html, &$buffer, &$current_list_type, &$render_list_tree) {
+                if (empty($buffer)) return;
+
+                $html .= '<' . $current_list_type . '>';
+                foreach ($buffer as $item) {
+                    $html .= '<li>' . parse_inline_wikitext($item['content']);
+                    $html .= $render_list_tree($item['children']);
+                    $html .= '</li>';
+                }
+                $html .= '</' . $current_list_type . '>';
+                $buffer = [];
+            };
+
+            foreach ($tree as $item) {
+                if ($item['type'] !== $current_list_type) {
+                    $flush_buffer();
+                    $current_list_type = $item['type'];
+                }
+                $buffer[] = $item;
+            }
+            $flush_buffer(); // Flush the last group
+
+            return $html;
+        };
+
+        $list_html = $render_list_tree($list_tree);
+
         return $make_placeholder($list_html);
     }, $text);
 
@@ -72,7 +166,7 @@ function parse_wikitext($text) {
             $tag = $in_header ? 'th' : 'td';
             $row_html = "<tr>";
             foreach ($cells as $cell) {
-                $row_html .= "<{$tag}>" . trim($cell) . "</{$tag}>";
+                $row_html .= "<{$tag}>" . parse_inline_wikitext(trim($cell)) . "</{$tag}>";
             }
             $row_html .= "</tr>";
 
@@ -97,19 +191,131 @@ function parse_wikitext($text) {
 
     // --- Inline elements ---
 
-    // 6. Bold and Italic
-    $text = preg_replace("/'''(.*?)'''/", '<strong>$1</strong>', $text);
-    $text = preg_replace("/''(.*?)''/", '<em>$1</em>', $text);
-
     // 7. Images and Videos (as block-level figures/divs, so placeholder them)
-    $text = preg_replace_callback('/\[\[Image:(https?:\/\/[^\s|\]]+)\|([^\]]+)\]\]/', function ($matches) use ($make_placeholder) {
+    $text = preg_replace_callback('/\[\[Image:(https?:\/\/[^\s|\]]+)((?:\|[^|\]]*)*)\]\]/', function ($matches) use ($make_placeholder) {
+        // Parse URL and options
         $url = htmlspecialchars_decode($matches[1]);
-        $caption = trim($matches[2]);
-        $figure = '<figure class="figure">
-                     <img src="' . $url . '" class="img-fluid" alt="' . htmlspecialchars($caption) . '">
-                     <figcaption class="figure-caption">' . htmlspecialchars($caption) . '</figcaption>
-                   </figure>';
-        return $make_placeholder($figure);
+        $options_str = $matches[2];
+        $parts = explode('|', $options_str);
+        array_shift($parts); // Remove the empty string from the first pipe
+
+        $options = [
+            'type' => 'default', 'align' => null, 'size' => null, 'upright' => null,
+            'alt' => null, 'link' => null, 'class' => null, 'border' => false, 'caption' => ''
+        ];
+        $caption_parts = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if (in_array($part, ['thumb', 'thumbnail', 'frame', 'frameless'])) {
+                $options['type'] = ($part === 'thumbnail' ? 'thumb' : $part);
+            } elseif (in_array($part, ['left', 'right', 'center', 'none'])) {
+                $options['align'] = $part;
+            } elseif ($part === 'border') {
+                $options['border'] = true;
+            } elseif (preg_match('/^upright\s*=\s*([0-9\.]+)/', $part, $m)) {
+                $options['upright'] = (float)$m[1];
+            } elseif ($part === 'upright') {
+                $options['upright'] = 0.75;
+            } elseif (preg_match('/^(\d+)\s*px$/', $part, $m)) {
+                $options['size'] = $m[1] . 'px';
+            } elseif (preg_match('/^x(\d+)\s*px$/', $part, $m)) {
+                $options['size'] = 'x' . $m[1] . 'px';
+            } elseif (preg_match('/^(\d+)\s*x\s*(\d+)\s*px$/', $part, $m)) {
+                $options['size'] = $m[1] . 'x' . $m[2] . 'px';
+            } elseif (preg_match('/^alt\s*=\s*(.*)/', $part, $m)) {
+                $options['alt'] = $m[1];
+            } elseif (preg_match('/^link\s*=\s*(.*)/', $part, $m)) {
+                $options['link'] = $m[1];
+            } elseif (preg_match('/^class\s*=\s*(.*)/', $part, $m)) {
+                $options['class'] = $m[1];
+            } else {
+                $caption_parts[] = $part;
+            }
+        }
+        $options['caption'] = implode('|', $caption_parts);
+
+        // --- HTML Generation ---
+        $img_attrs = ['src' => $url, 'class' => 'img-fluid'];
+        $figure_classes = ['figure'];
+        $wrapper_classes = [];
+
+        // Alt text
+        $img_attrs['alt'] = htmlspecialchars($options['alt'] ?: $options['caption']);
+
+        // Alignment
+        if ($options['align']) {
+            if ($options['type'] === 'thumb' || $options['type'] === 'frame') {
+                 $wrapper_classes[] = 'figure-wrapper'; // Wrapper for alignment
+                 if ($options['align'] === 'left') $wrapper_classes[] = 'float-start me-3';
+                 if ($options['align'] === 'right') $wrapper_classes[] = 'float-end ms-3';
+                 if ($options['align'] === 'center') $wrapper_classes[] = 'mx-auto d-table';
+            } else {
+                 // Plain image alignment
+                 if ($options['align'] === 'left') $img_attrs['class'] .= ' float-start me-3';
+                 if ($options['align'] === 'right') $img_attrs['class'] .= ' float-end ms-3';
+                 if ($options['align'] === 'center') $img_attrs['class'] .= ' mx-auto d-block';
+            }
+        }
+
+        // Sizing
+        $img_styles = [];
+        $figure_styles = [];
+        if ($options['size']) {
+            if (preg_match('/^(\d+)px$/', $options['size'], $m)) {
+                $img_styles[] = 'width: ' . $m[1] . 'px; height: auto;';
+                if ($options['type'] === 'thumb') $figure_styles[] = 'width: ' . $m[1] . 'px;';
+            } elseif (preg_match('/^x(\d+)px$/', $options['size'], $m)) {
+                $img_styles[] = 'height: ' . $m[1] . 'px; width: auto;';
+            } elseif (preg_match('/^(\d+)x(\d+)px$/', $options['size'], $m)) {
+                $img_styles[] = 'max-width: ' . $m[1] . 'px; max-height: ' . $m[2] . 'px;';
+                 if ($options['type'] === 'thumb') $figure_styles[] = 'max-width: ' . $m[1] . 'px;';
+            }
+        } elseif ($options['upright']) {
+            $width = round(220 * $options['upright']); // Assuming default 220px
+            $img_styles[] = 'width: ' . $width . 'px; height: auto;';
+            if ($options['type'] === 'thumb') $figure_styles[] = 'width: ' . $width . 'px;';
+        }
+
+        if ($options['class']) $img_attrs['class'] .= ' ' . htmlspecialchars($options['class']);
+        if ($options['border']) $img_attrs['class'] .= ' border';
+        if (!empty($img_styles)) $img_attrs['style'] = implode(' ', $img_styles);
+
+        $img_attr_str = '';
+        foreach ($img_attrs as $key => $val) {
+            $img_attr_str .= ' ' . $key . '="' . $val . '"';
+        }
+        $img_tag = '<img' . $img_attr_str . '>';
+
+        if ($options['link']) {
+            $img_tag = '<a href="' . htmlspecialchars($options['link']) . '">' . $img_tag . '</a>';
+        }
+
+        $html = '';
+        if ($options['type'] === 'thumb' || $options['type'] === 'frame') {
+            if($options['type'] === 'thumb') $figure_classes[] = 'figure-thumbnail';
+            $figure_attrs = ['class' => implode(' ', $figure_classes)];
+            if(!empty($figure_styles)) $figure_attrs['style'] = implode(' ', $figure_styles);
+
+            $figure_attr_str = '';
+            foreach ($figure_attrs as $key => $val) {
+                $figure_attr_str .= ' ' . $key . '="' . $val . '"';
+            }
+
+            $html = '<div class="' . implode(' ', $wrapper_classes) . '">';
+            $html .= '<figure' . $figure_attr_str . '>';
+            $html .= $img_tag;
+            if (!empty($options['caption'])) {
+                $html .= '<figcaption class="figure-caption">' . parse_inline_wikitext($options['caption']) . '</figcaption>';
+            }
+            $html .= '</figure></div>';
+            if(empty($wrapper_classes)) $html = substr($html, 5, -6); // remove wrapper if not needed
+
+        } else { // Plain image
+            $html = $img_tag;
+        }
+
+        return $make_placeholder($html);
     }, $text);
 
     $text = preg_replace_callback('/\[\[Video:(https?:\/\/(?:www\.youtube\.com\/watch\?v=|youtu\.be\/)[^\s\]]+)\]\]/', function ($matches) use ($make_placeholder) {
@@ -127,27 +333,6 @@ function parse_wikitext($text) {
         return $make_placeholder($video_div);
     }, $text);
 
-    // 8. Colored Text
-    $text = preg_replace_callback('/\{\{color:([a-zA-Z]+|#[0-9a-fA-F]{3,6})\|(.*?)\}\}/', function ($matches) {
-        $color = htmlspecialchars_decode($matches[1]);
-        $content = $matches[2];
-        if (!preg_match('/^(?:[a-zA-Z]+|#[0-9a-fA-F]{3,6})$/', $color)) {
-            return $matches[0]; // Invalid color
-        }
-        return '<span style="color:' . $color . ';">' . $content . '</span>';
-    }, $text);
-
-    // 9. Links (Internal and External)
-    // Exclude [[Image...]] and [[Video...]]
-    $text = preg_replace_callback('/\[\[([^\]|:\n]+)(?:\|([^\]\n]+))?\]\]/', function ($matches) {
-        $page = trim($matches[1]);
-        $display = isset($matches[2]) ? trim($matches[2]) : $page;
-        $url = 'view.php?title=' . urlencode($page);
-        return '<a href="' . $url . '">' . htmlspecialchars($display) . '</a>';
-    }, $text);
-
-    $text = preg_replace('/\[(https?:\/\/[^\s\]]+)\s+([^\]]+)\]/', '<a href="$1" target="_blank" rel="noopener noreferrer">$2</a>', $text);
-
     // --- Final Processing ---
 
     // 10. Paragraphs
@@ -158,13 +343,16 @@ function parse_wikitext($text) {
         $block = trim($block);
         if (empty($block)) continue;
 
+        // Parse inline elements for the whole block first.
+        $parsed_block = parse_inline_wikitext($block);
+
         if (strpos($block, '%%PLACEHOLDER_') === false) {
-            // This is a simple paragraph, apply nl2br for single line breaks
-            $html .= '<p>' . nl2br($block, false) . "</p>\n";
+            // This is a simple paragraph, wrap in <p> and apply nl2br for single line breaks
+            $html .= '<p>' . nl2br($parsed_block, false) . "</p>\n";
         } else {
-            // This block contains placeholders, so just add it.
+            // This block contains placeholders, so just add it without <p> tags.
             // The nl2br is not needed as block elements handle their own spacing.
-            $html .= $block . "\n";
+            $html .= $parsed_block . "\n";
         }
     }
 


### PR DESCRIPTION
…tions

This commit introduces several major improvements to the wikitext parser:

1.  **Nested Lists**: Implemented a tree-based parser to correctly handle and render nested lists (e.g., using `*`, `**`, `#`).

2.  **Advanced Image Rendering**: The image syntax now supports multiple options for alignment, sizing, type, and more, similar to MediaWiki syntax. This allows for `[[Image:url|thumb|left|250px|alt=...|caption]]`.

3.  **Parser Refactoring**: The inline element parsing (bold, italic, etc.) was refactored into a dedicated function. This resolves a bug where formatting was not applied inside lists and tables, and it improves the overall structure of the parser.