### PR TITLE
Fix: make tables responsive on mobile

### DIFF
--- a/exercises/index.php
+++ b/exercises/index.php
@@ -78,7 +78,7 @@ $total_pages = ceil($total_exercises / $limit);
             <div class="card-header">
                 Elenco Esercizi (Pagina <?php echo $page; ?> di <?php echo $total_pages; ?>)
             </div>
-            <div class="card-body">
+            <div class="card-body table-responsive">
                 <table class="table table-striped">
                     <thead>
                         <tr>

--- a/lessons/index.php
+++ b/lessons/index.php
@@ -114,7 +114,7 @@ $is_teacher = $_SESSION['role'] === 'teacher';
             <div class="card-header">
                 Elenco Lezioni (Pagina <?php echo $page; ?> di <?php echo $total_pages; ?>)
             </div>
-            <div class="card-body">
+            <div class="card-body table-responsive">
                 <table class="table table-striped">
                     <thead>
                         <tr>


### PR DESCRIPTION
The tables in the lessons and exercises pages were overflowing on mobile viewports.

This change wraps the tables in a `div` with the `table-responsive` Bootstrap class, which makes them horizontally scrollable on small screens.