### PR TITLE
Fix: Generate responsive tables in wikitext parser

### DIFF
--- a/exercises/index.php
+++ b/exercises/index.php
@@ -79,43 +79,45 @@ $total_pages = ceil($total_exercises / $limit);
                 Elenco Esercizi (Pagina <?php echo $page; ?> di <?php echo $total_pages; ?>)
             </div>
             <div class="card-body">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th scope="col">Titolo</th>
-                            <th scope="col">Tipo</th>
-                            <th scope="col">Stato</th>
-                            <th scope="col">Azioni</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if (empty($exercises)): ?>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
                             <tr>
-                                <td colspan="4" class="text-center">Nessun esercizio trovato.</td>
+                                <th scope="col">Titolo</th>
+                                <th scope="col">Tipo</th>
+                                <th scope="col">Stato</th>
+                                <th scope="col">Azioni</th>
                             </tr>
-                        <?php else: ?>
-                            <?php foreach ($exercises as $exercise): ?>
+                        </thead>
+                        <tbody>
+                            <?php if (empty($exercises)): ?>
                                 <tr>
-                                    <td><?php echo htmlspecialchars($exercise->title); ?></td>
-                                    <td><?php echo htmlspecialchars($exercise->type); ?></td>
-                                    <td>
-                                        <?php if ($exercise->enabled): ?>
-                                            <span class="badge bg-success">Abilitato</span>
-                                        <?php else: ?>
-                                            <span class="badge bg-secondary">Disabilitato</span>
-                                        <?php endif; ?>
-                                    </td>
-                                    <td>
-                                        <a href="view.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-info">Visualizza</a>
-                                        <a href="edit.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-warning">Modifica</a>
-                                        <a href="delete.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Sei sicuro di voler cancellare questo esercizio?');">Cancella</a>
-                                        <!-- TODO: Add enable/disable toggle -->
-                                    </td>
+                                    <td colspan="4" class="text-center">Nessun esercizio trovato.</td>
                                 </tr>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+                            <?php else: ?>
+                                <?php foreach ($exercises as $exercise): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($exercise->title); ?></td>
+                                        <td><?php echo htmlspecialchars($exercise->type); ?></td>
+                                        <td>
+                                            <?php if ($exercise->enabled): ?>
+                                                <span class="badge bg-success">Abilitato</span>
+                                            <?php else: ?>
+                                                <span class="badge bg-secondary">Disabilitato</span>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td>
+                                            <a href="view.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-info">Visualizza</a>
+                                            <a href="edit.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-warning">Modifica</a>
+                                            <a href="delete.php?id=<?php echo $exercise->id; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Sei sicuro di voler cancellare questo esercizio?');">Cancella</a>
+                                            <!-- TODO: Add enable/disable toggle -->
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
             </div>
             <?php if ($total_pages > 1): ?>
             <div class="card-footer">

--- a/lessons/index.php
+++ b/lessons/index.php
@@ -115,37 +115,39 @@ $is_teacher = $_SESSION['role'] === 'teacher';
                 Elenco Lezioni (Pagina <?php echo $page; ?> di <?php echo $total_pages; ?>)
             </div>
             <div class="card-body">
-                <table class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th scope="col">Titolo</th>
-                            <th scope="col">Tags</th>
-                            <th scope="col">Azioni</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php if (empty($lessons)): ?>
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
                             <tr>
-                                <td colspan="3" class="text-center">Nessuna lezione trovata.</td>
+                                <th scope="col">Titolo</th>
+                                <th scope="col">Tags</th>
+                                <th scope="col">Azioni</th>
                             </tr>
-                        <?php else: ?>
-                            <?php foreach ($lessons as $lesson): ?>
+                        </thead>
+                        <tbody>
+                            <?php if (empty($lessons)): ?>
                                 <tr>
-                                    <td><?php echo htmlspecialchars($lesson->title); ?></td>
-                                    <td><?php echo htmlspecialchars($lesson->tags); ?></td>
-                                    <td>
-                                        <a href="view.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-info">Visualizza</a>
-                                        <?php if ($is_teacher): ?>
-                                        <a href="feedback.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-success">Riscontro Alunni</a>
-                                        <a href="edit.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-warning">Modifica</a>
-                                        <a href="delete.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-danger">Cancella</a>
-                                        <?php endif; ?>
-                                    </td>
+                                    <td colspan="3" class="text-center">Nessuna lezione trovata.</td>
                                 </tr>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
-                    </tbody>
-                </table>
+                            <?php else: ?>
+                                <?php foreach ($lessons as $lesson): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($lesson->title); ?></td>
+                                        <td><?php echo htmlspecialchars($lesson->tags); ?></td>
+                                        <td>
+                                            <a href="view.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-info">Visualizza</a>
+                                            <?php if ($is_teacher): ?>
+                                            <a href="feedback.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-success">Riscontro Alunni</a>
+                                            <a href="edit.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-warning">Modifica</a>
+                                            <a href="delete.php?id=<?php echo $lesson->id; ?>" class="btn btn-sm btn-danger">Cancella</a>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
             </div>
             <?php if ($total_pages > 1): ?>
             <div class="card-footer">

--- a/src/wikitext_parser.php
+++ b/src/wikitext_parser.php
@@ -143,12 +143,11 @@ function parse_wikitext($text) {
 
 
     // 5. Tables
-        $text = preg_replace_callback('/((?:^\|[^\n]*\n?)+)/m', function ($matches) use ($make_placeholder) {
+    $text = preg_replace_callback('/((?:^\|[^\n]*\n?)+)/m', function ($matches) use ($make_placeholder) {
         $table_text = trim($matches[1]);
         $rows = explode("\n", $table_text);
 
-        // Removed 'table' class, added inline-table style for content-width
-        $table_html = "<table class=\"table-bordered\" style=\"display: inline-table;\">\n";
+        $table_html = "<div class=\"table-responsive\"><table class=\"table table-striped table-bordered\">\n";
         $thead_html = '';
         $tbody_html = '';
         $in_header = true;
@@ -184,7 +183,7 @@ function parse_wikitext($text) {
             $table_html .= "<tbody>{$tbody_html}</tbody>\n";
         }
 
-        $table_html .= "</table>";
+        $table_html .= "</table></div>";
         return $make_placeholder($table_html);
     }, $text);
 


### PR DESCRIPTION
This commit fixes the table rendering in `src/wikitext_parser.php` to ensure that tables generated from wikitext are responsive on mobile devices.

The parser now:
- Wraps the generated table in a `<div class="table-responsive">`.
- Adds the `table`, `table-striped`, and `table-bordered` classes for proper Bootstrap styling.
- Removes the incorrect `style="display: inline-table;"` inline style.

This addresses the final remaining issue of unresponsive tables in `lessons/view.php`.