### PR TITLE
Fix(synoptic-view): Ensure all lessons are displayed

### DIFF
--- a/synoptic_data.php
+++ b/synoptic_data.php
@@ -112,10 +112,6 @@ foreach ($udas as $uda) {
                         }
                     }
 
-                    if (empty($conoscenze) && empty($abilita) && $anno_corso) {
-                        continue;
-                    }
-
                     // Fetch exercises
                     $exercises = Exercise::findForLesson($lesson->id);
 


### PR DESCRIPTION
The synoptic view was failing to display lessons if they did not have associated 'knowledge' or 'skills' for a selected year filter. This was due to an overly restrictive condition that would skip the entire lesson.

This commit removes the faulty condition. Now, all lessons are consistently displayed, and the year filter correctly applies only to the 'knowledge' and 'skills' within each lesson, without hiding the lesson itself. This resolves the issue where the synoptic view appeared incomplete.