### PR TITLE
Fix(synoptic-view): Ensure full curriculum structure is always displayed

### DIFF
--- a/synoptic_data.php
+++ b/synoptic_data.php
@@ -112,10 +112,6 @@ foreach ($udas as $uda) {
                         }
                     }
 
-                    if (empty($conoscenze) && empty($abilita) && $anno_corso) {
-                        continue;
-                    }
-
                     // Fetch exercises
                     $exercises = Exercise::findForLesson($lesson->id);
 
@@ -131,24 +127,20 @@ foreach ($udas as $uda) {
             }
         }
 
-        if (!empty($lessonData) || !$anno_corso) {
-            $moduleData[] = [
-                'id' => $module->id,
-                'name' => $module->name,
-                'description' => $module->description,
-                'lessons' => $lessonData,
-            ];
-        }
-    }
-
-    if (!empty($moduleData) || !$anno_corso) {
-        $result[] = [
-            'id' => $uda->id,
-            'name' => $uda->name,
-            'description' => $uda->description,
-            'modules' => $moduleData,
+        $moduleData[] = [
+            'id' => $module->id,
+            'name' => $module->name,
+            'description' => $module->description,
+            'lessons' => $lessonData,
         ];
     }
+
+    $result[] = [
+        'id' => $uda->id,
+        'name' => $uda->name,
+        'description' => $uda->description,
+        'modules' => $moduleData,
+    ];
 }
 
 echo json_encode($result, JSON_PRETTY_PRINT);


### PR DESCRIPTION
The synoptic view was failing to display lessons, modules, and UDAs correctly when a year filter was applied. This was due to a cascading filter logic that would hide parent elements (UDAs, modules) if their children were filtered out by the year selection.

This commit removes all conditional logic that was hiding parts of the curriculum structure. The UDA/Module/Lesson hierarchy will now always be present in the data, and the year filter will only apply to the content within the lessons (knowledge and skills), as intended. This provides a more consistent and less confusing user experience.