### PR TITLE
feat: Add previous lesson indicator to order lessons

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -30,9 +30,12 @@ CREATE TABLE `lessons` (
   `title` varchar(255) NOT NULL,
   `content` text NOT NULL,
   `tags` varchar(255) DEFAULT NULL,
+  `previous_lesson_id` int(11) DEFAULT NULL,
   `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `previous_lesson_id` (`previous_lesson_id`),
+  CONSTRAINT `lessons_ibfk_1` FOREIGN KEY (`previous_lesson_id`) REFERENCES `lessons` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 --

--- a/lessons/edit.php
+++ b/lessons/edit.php
@@ -16,6 +16,7 @@ if ($_SESSION["role"] !== 'teacher') {
 
 $lesson = null;
 $modules = Module::findAll();
+$all_lessons = Lesson::findAll(null);
 $all_conoscenze = Conoscenza::findAll();
 $all_abilita = Abilita::findAll();
 $pageTitle = 'Aggiungi Nuova Lezione';
@@ -57,6 +58,19 @@ if (isset($_GET['id']) && !empty($_GET['id'])) {
                             <?php foreach ($modules as $module): ?>
                                 <option value="<?php echo $module->id; ?>" <?php echo (isset($lesson) && $lesson->module_id == $module->id) ? 'selected' : ''; ?>>
                                     <?php echo htmlspecialchars($module->name); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="previous_lesson_id" class="form-label">Lezione Precedente</label>
+                        <select class="form-select" id="previous_lesson_id" name="previous_lesson_id">
+                            <option value="">Nessuna (prima lezione)</option>
+                            <?php foreach ($all_lessons as $prev_lesson): ?>
+                                <?php if (isset($lesson) && $lesson->id === $prev_lesson->id) continue; ?>
+                                <option value="<?php echo $prev_lesson->id; ?>" <?php echo (isset($lesson) && $lesson->previous_lesson_id == $prev_lesson->id) ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars($prev_lesson->title); ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>

--- a/lessons/save.php
+++ b/lessons/save.php
@@ -20,6 +20,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             'content' => trim($_POST['content']),
             'tags' => isset($_POST['tags']) ? trim($_POST['tags']) : '',
             'module_id' => isset($_POST['module_id']) && !empty($_POST['module_id']) ? (int)$_POST['module_id'] : null,
+            'previous_lesson_id' => isset($_POST['previous_lesson_id']) && !empty($_POST['previous_lesson_id']) ? (int)$_POST['previous_lesson_id'] : null,
             'conoscenze' => $_POST['conoscenze'] ?? [],
             'abilita' => $_POST['abilita'] ?? []
         ];

--- a/src/Lesson.php
+++ b/src/Lesson.php
@@ -7,6 +7,7 @@ class Lesson
     public $content;
     public $tags;
     public $module_id;
+    public $previous_lesson_id;
     public $created_at;
     public $updated_at;
 
@@ -21,6 +22,7 @@ class Lesson
         $this->content = $data['content'] ?? '';
         $this->tags = $data['tags'] ?? '';
         $this->module_id = $data['module_id'] ?? null;
+        $this->previous_lesson_id = $data['previous_lesson_id'] ?? null;
         $this->created_at = $data['created_at'] ?? null;
         $this->updated_at = $data['updated_at'] ?? null;
 
@@ -36,13 +38,23 @@ class Lesson
      * @param int $offset
      * @return Lesson[]
      */
-    public static function findAll($limit, $offset)
+    public static function findAll($limit = 10, $offset = 0)
     {
         $database = new Database();
         $pdo = $database->getConnection();
-        $stmt = $pdo->prepare('SELECT * FROM lessons ORDER BY updated_at DESC LIMIT :limit OFFSET :offset');
-        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
-        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+
+        $sql = 'SELECT * FROM lessons ORDER BY updated_at DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
+
+        $stmt = $pdo->prepare($sql);
+
+        if ($limit !== null) {
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        }
+
         $stmt->execute();
 
         $lessonsData = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -148,21 +160,23 @@ class Lesson
             $pdo->beginTransaction();
 
             if ($this->id) {
-                $stmt = $pdo->prepare('UPDATE lessons SET title = :title, content = :content, tags = :tags, module_id = :module_id WHERE id = :id');
+                $stmt = $pdo->prepare('UPDATE lessons SET title = :title, content = :content, tags = :tags, module_id = :module_id, previous_lesson_id = :previous_lesson_id WHERE id = :id');
                 $params = [
                     'id' => $this->id,
                     'title' => $this->title,
                     'content' => $this->content,
                     'tags' => $this->tags,
                     'module_id' => $this->module_id,
+                    'previous_lesson_id' => $this->previous_lesson_id,
                 ];
             } else {
-                $stmt = $pdo->prepare('INSERT INTO lessons (title, content, tags, module_id) VALUES (:title, :content, :tags, :module_id)');
+                $stmt = $pdo->prepare('INSERT INTO lessons (title, content, tags, module_id, previous_lesson_id) VALUES (:title, :content, :tags, :module_id, :previous_lesson_id)');
                 $params = [
                     'title' => $this->title,
                     'content' => $this->content,
                     'tags' => $this->tags,
                     'module_id' => $this->module_id,
+                    'previous_lesson_id' => $this->previous_lesson_id,
                 ];
             }
 


### PR DESCRIPTION
This commit introduces a new feature that allows ordering lessons by linking them to a previous lesson.

Changes include:
- Modified `database.sql` to add a `previous_lesson_id` column to the `lessons` table.
- Updated the `Lesson` class in `src/Lesson.php` to include the `previous_lesson_id` property and handle it in the `save` method.
- Modified `lessons/edit.php` to include a dropdown menu for selecting the previous lesson.
- Updated `lessons/save.php` to process the `previous_lesson_id` from the form.