### PR TITLE
feat: Implement and display full data inheritance for all entities

### DIFF
--- a/abilita/index.php
+++ b/abilita/index.php
@@ -19,7 +19,14 @@ $entity_name = 'Abilità';
 $table_name = 'abilita';
 $columns = [
     'nome' => 'Nome',
-    'tipo' => 'Tipo'
+    'tipo' => 'Tipo',
+    'anni_corso' => 'Anni di Corso',
+    'discipline' => 'Discipline'
+];
+
+$renderers = [
+    'anni_corso' => 'anniCorsoBadge',
+    'discipline' => 'arrayBadge'
 ];
 
 $custom_actions = [

--- a/abilita/view.php
+++ b/abilita/view.php
@@ -38,18 +38,6 @@ foreach ($all_discipline as $d) {
     $discipline_map[$d->id] = $d->nome;
 }
 
-// Derive disciplines from linked conoscenze
-$derived_discipline_ids = [];
-if (!empty($abilita->conoscenze)) {
-    foreach ($abilita->conoscenze as $conoscenza_id) {
-        $conoscenza = $conoscenza_manager->findById($conoscenza_id);
-        if ($conoscenza && !empty($conoscenza->discipline)) {
-            $derived_discipline_ids = array_merge($derived_discipline_ids, $conoscenza->discipline);
-        }
-    }
-}
-$derived_discipline_ids = array_unique($derived_discipline_ids);
-
 ?>
     <div class="container mt-5">
         <h2>Dettaglio: <?php echo htmlspecialchars($abilita->nome); ?></h2>
@@ -73,23 +61,27 @@ $derived_discipline_ids = array_unique($derived_discipline_ids);
                     <p>Nessuna conoscenza collegata.</p>
                 <?php endif; ?>
 
-                <h5 class="card-title mt-4">Discipline (derivate dalle conoscenze)</h5>
-                <?php if (!empty($derived_discipline_ids)): ?>
-                    <ul>
-                        <?php foreach ($derived_discipline_ids as $disciplina_id): ?>
-                            <li><?php echo htmlspecialchars($discipline_map[$disciplina_id] ?? 'ID Sconosciuto'); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                <?php else: ?>
-                    <p>Nessuna disciplina derivata (collegare a conoscenze per vederle).</p>
-                <?php endif; ?>
-
                 <h5 class="card-title mt-4">Anni di Corso</h5>
+                <div>
                 <?php if (!empty($abilita->anni_corso)): ?>
-                    <p><?php echo implode(', ', array_map(function($y) { return $y . '° anno'; }, $abilita->anni_corso)); ?></p>
+                    <?php foreach ($abilita->anni_corso as $anno): ?>
+                        <span class="badge bg-info me-1"><?php echo htmlspecialchars($anno); ?></span>
+                    <?php endforeach; ?>
                 <?php else: ?>
-                    <p>Nessun anno di corso specificato.</p>
+                    <p>Nessun anno di corso calcolato.</p>
                 <?php endif; ?>
+                </div>
+
+                <h5 class="card-title mt-4">Discipline Ereditate</h5>
+                <div>
+                <?php if (!empty($abilita->discipline)): ?>
+                    <?php foreach ($abilita->discipline as $disciplina): ?>
+                        <span class="badge bg-secondary me-1"><?php echo htmlspecialchars($disciplina); ?></span>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <p>Nessuna disciplina calcolata.</p>
+                <?php endif; ?>
+                </div>
             </div>
         </div>
 

--- a/assets/js/dynamic-table.js
+++ b/assets/js/dynamic-table.js
@@ -97,6 +97,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     default:
                         return '<span class="badge bg-secondary">Sconosciuto</span>';
                 }
+            },
+            arrayBadge: (data, color = 'secondary') => {
+                if (!data || !Array.isArray(data) || data.length === 0) {
+                    return '';
+                }
+                return data.map(item => `<span class="badge bg-${color} me-1">${item}</span>`).join(' ');
+            },
+            anniCorsoBadge: (data) => {
+                return renderers.arrayBadge(data, 'info');
             }
         };
 

--- a/competenze/index.php
+++ b/competenze/index.php
@@ -28,7 +28,14 @@ $selects = [
 ];
 $columns = [
     'nome' => 'Nome',
-    'tipologia' => 'Tipologia'
+    'tipologia' => 'Tipologia',
+    'anni_corso' => 'Anni di Corso',
+    'discipline' => 'Discipline'
+];
+
+$renderers = [
+    'anni_corso' => 'anniCorsoBadge',
+    'discipline' => 'arrayBadge'
 ];
 
 $custom_actions = [

--- a/competenze/view.php
+++ b/competenze/view.php
@@ -77,11 +77,26 @@ foreach ($all_abilita as $a) {
                 <?php endif; ?>
 
                 <h5 class="card-title mt-4">Anni di Corso</h5>
+                <div>
                 <?php if (!empty($competenza->anni_corso)): ?>
-                    <p><?php echo implode(', ', array_map(function($y) { return $y . '° anno'; }, $competenza->anni_corso)); ?></p>
+                    <?php foreach ($competenza->anni_corso as $anno): ?>
+                        <span class="badge bg-info me-1"><?php echo htmlspecialchars($anno); ?></span>
+                    <?php endforeach; ?>
                 <?php else: ?>
-                    <p>Nessun anno di corso.</p>
+                    <p>Nessun anno di corso calcolato.</p>
                 <?php endif; ?>
+                </div>
+
+                <h5 class="card-title mt-4">Discipline Ereditate</h5>
+                <div>
+                <?php if (!empty($competenza->discipline)): ?>
+                    <?php foreach ($competenza->discipline as $disciplina): ?>
+                        <span class="badge bg-secondary me-1"><?php echo htmlspecialchars($disciplina); ?></span>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <p>Nessuna disciplina calcolata.</p>
+                <?php endif; ?>
+                </div>
             </div>
         </div>
 

--- a/conoscenze/index.php
+++ b/conoscenze/index.php
@@ -18,7 +18,14 @@ $page_title = 'Gestione Conoscenze';
 $entity_name = 'Conoscenza';
 $table_name = 'conoscenze';
 $columns = [
-    'nome' => 'Nome'
+    'nome' => 'Nome',
+    'anni_corso' => 'Anni di Corso',
+    'discipline' => 'Discipline'
+];
+
+$renderers = [
+    'anni_corso' => 'anniCorsoBadge',
+    'discipline' => 'arrayBadge'
 ];
 
 $custom_actions = [

--- a/conoscenze/view.php
+++ b/conoscenze/view.php
@@ -37,23 +37,27 @@ foreach ($all_discipline as $d) {
                 <h5 class="card-title">Descrizione</h5>
                 <p class="card-text"><?php echo nl2br(htmlspecialchars($conoscenza->descrizione)); ?></p>
 
-                <h5 class="card-title mt-4">Discipline Correlate</h5>
-                <?php if (!empty($conoscenza->discipline)): ?>
-                    <ul>
-                        <?php foreach ($conoscenza->discipline as $disciplina_id): ?>
-                            <li><?php echo htmlspecialchars($discipline_map[$disciplina_id] ?? 'ID Sconosciuto'); ?></li>
-                        <?php endforeach; ?>
-                    </ul>
-                <?php else: ?>
-                    <p>Nessuna disciplina correlata.</p>
-                <?php endif; ?>
-
                 <h5 class="card-title mt-4">Anni di Corso</h5>
+                <div>
                 <?php if (!empty($conoscenza->anni_corso)): ?>
-                    <p><?php echo implode(', ', array_map(function($y) { return $y . '° anno'; }, $conoscenza->anni_corso)); ?></p>
+                    <?php foreach ($conoscenza->anni_corso as $anno): ?>
+                        <span class="badge bg-info me-1"><?php echo htmlspecialchars($anno); ?></span>
+                    <?php endforeach; ?>
                 <?php else: ?>
-                    <p>Nessun anno di corso specificato.</p>
+                    <p>Nessun anno di corso calcolato.</p>
                 <?php endif; ?>
+                </div>
+
+                <h5 class="card-title mt-4">Discipline Ereditate</h5>
+                <div>
+                <?php if (!empty($conoscenza->discipline)): ?>
+                    <?php foreach ($conoscenza->discipline as $disciplina): ?>
+                        <span class="badge bg-secondary me-1"><?php echo htmlspecialchars($disciplina); ?></span>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <p>Nessuna disciplina calcolata.</p>
+                <?php endif; ?>
+                </div>
             </div>
         </div>
 

--- a/database.sql
+++ b/database.sql
@@ -348,3 +348,42 @@ CREATE TABLE `abilita_anni_corso` (
   PRIMARY KEY (`abilita_id`, `anno_corso`),
   FOREIGN KEY (`abilita_id`) REFERENCES `abilita`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Relazione Competenze -> Anno Corso (N a N)
+CREATE TABLE `competenza_anni_corso` (
+  `competenza_id` INT(11) NOT NULL,
+  `anno_corso` TINYINT NOT NULL,
+  PRIMARY KEY (`competenza_id`, `anno_corso`),
+  FOREIGN KEY (`competenza_id`) REFERENCES `competenze`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- tabelle di relazione per le discipline ereditate
+--
+
+-- Relazione Conoscenze -> Discipline (N a N)
+CREATE TABLE `conoscenza_discipline` (
+  `conoscenza_id` INT(11) NOT NULL,
+  `disciplina_id` INT(11) NOT NULL,
+  PRIMARY KEY (`conoscenza_id`, `disciplina_id`),
+  FOREIGN KEY (`conoscenza_id`) REFERENCES `conoscenze`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`disciplina_id`) REFERENCES `discipline`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Relazione Abilità -> Discipline (N a N)
+CREATE TABLE `abilita_discipline` (
+  `abilita_id` INT(11) NOT NULL,
+  `disciplina_id` INT(11) NOT NULL,
+  PRIMARY KEY (`abilita_id`, `disciplina_id`),
+  FOREIGN KEY (`abilita_id`) REFERENCES `abilita`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`disciplina_id`) REFERENCES `discipline`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Relazione Competenze -> Discipline (N a N)
+CREATE TABLE `competenza_discipline` (
+  `competenza_id` INT(11) NOT NULL,
+  `disciplina_id` INT(11) NOT NULL,
+  PRIMARY KEY (`competenza_id`, `disciplina_id`),
+  FOREIGN KEY (`competenza_id`) REFERENCES `competenze`(`id`) ON DELETE CASCADE,
+  FOREIGN KEY (`disciplina_id`) REFERENCES `discipline`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/lessons/index.php
+++ b/lessons/index.php
@@ -13,7 +13,8 @@ $table_name = 'lessons';
 $joins = [
     'LEFT JOIN uda_lessons ON lessons.id = uda_lessons.lesson_id',
     'LEFT JOIN udas ON uda_lessons.uda_id = udas.id',
-    'LEFT JOIN modules ON udas.module_id = modules.id'
+    'LEFT JOIN modules ON udas.module_id = modules.id',
+    'LEFT JOIN discipline ON modules.disciplina_id = discipline.id'
 ];
 
 $selects = [
@@ -21,11 +22,15 @@ $selects = [
     'lessons.title as title',
     'modules.name as module_name',
     'udas.name as uda_name',
-    'lessons.tags as tags'
+    'lessons.tags as tags',
+    'discipline.nome as disciplina_nome',
+    'modules.anno_corso as anno_corso'
 ];
 
 $columns = [
     'title' => 'Titolo',
+    'disciplina_nome' => 'Disciplina',
+    'anno_corso' => 'Anno',
     'module_name' => 'Modulo',
     'uda_name' => 'UDA',
     'tags' => 'Tags'

--- a/lessons/view.php
+++ b/lessons/view.php
@@ -146,9 +146,17 @@ if ($lesson) {
             <div class="card">
                 <div class="card-header">
                     <h1 class="h2 mb-0"><?php echo htmlspecialchars($lesson->title); ?></h1>
-                    <?php if (!empty($lesson->tags)): ?>
-                        <small class="text-muted">Tags: <?php echo htmlspecialchars($lesson->tags); ?></small>
-                    <?php endif; ?>
+                    <div>
+                        <?php if ($lesson->anno_corso): ?>
+                            <span class="badge bg-info me-2">Anno <?php echo htmlspecialchars($lesson->anno_corso); ?></span>
+                        <?php endif; ?>
+                        <?php if ($lesson->disciplina_nome): ?>
+                             <span class="badge bg-primary me-2"><?php echo htmlspecialchars($lesson->disciplina_nome); ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($lesson->tags)): ?>
+                            <small class="text-muted">Tags: <?php echo htmlspecialchars($lesson->tags); ?></small>
+                        <?php endif; ?>
+                    </div>
                 </div>
                 <div class="card-body">
                     <div id="lesson-content" class="wikitext-content">

--- a/src/Abilita.php
+++ b/src/Abilita.php
@@ -11,6 +11,8 @@ class Abilita
 
     // Related data
     public $conoscenze;
+    public $anni_corso;
+    public $discipline;
 
     public function __construct($db, $data = [])
     {
@@ -22,6 +24,8 @@ class Abilita
 
         // These will be loaded separately
         $this->conoscenze = $data['conoscenze'] ?? [];
+        $this->anni_corso = $data['anni_corso'] ?? [];
+        $this->discipline = $data['discipline'] ?? [];
     }
 
     /**
@@ -36,9 +40,58 @@ class Abilita
 
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
         $abilita_list = [];
+        $abilita_ids = [];
         foreach ($results as $data) {
             $abilita_list[] = new self($this->conn, $data);
+            $abilita_ids[] = $data['id'];
         }
+
+        if (empty($abilita_ids)) {
+            return $abilita_list;
+        }
+
+        // Fetch all related anni_corso in a single query
+        $ids_placeholder = implode(',', array_fill(0, count($abilita_ids), '?'));
+        $stmt_anni = $this->conn->prepare("
+            SELECT abilita_id, anno_corso
+            FROM abilita_anni_corso
+            WHERE abilita_id IN ({$ids_placeholder})
+            ORDER BY anno_corso ASC
+        ");
+        $stmt_anni->execute($abilita_ids);
+        $anni_map = [];
+        while ($row = $stmt_anni->fetch(PDO::FETCH_ASSOC)) {
+            $anni_map[$row['abilita_id']][] = $row['anno_corso'];
+        }
+
+        // Assign the anni_corso to each
+        foreach ($abilita_list as $abilita) {
+            if (isset($anni_map[$abilita->id])) {
+                $abilita->anni_corso = $anni_map[$abilita->id];
+            }
+        }
+
+        // Fetch all related disciplines in a single query
+        $stmt_disc = $this->conn->prepare("
+            SELECT ad.abilita_id, d.nome
+            FROM abilita_discipline ad
+            JOIN discipline d ON ad.disciplina_id = d.id
+            WHERE ad.abilita_id IN ({$ids_placeholder})
+            ORDER BY d.nome ASC
+        ");
+        $stmt_disc->execute($abilita_ids);
+        $disc_map = [];
+        while ($row = $stmt_disc->fetch(PDO::FETCH_ASSOC)) {
+            $disc_map[$row['abilita_id']][] = $row['nome'];
+        }
+
+        // Assign the disciplines to each
+        foreach ($abilita_list as $abilita) {
+            if (isset($disc_map[$abilita->id])) {
+                $abilita->discipline = $disc_map[$abilita->id];
+            }
+        }
+
         return $abilita_list;
     }
 
@@ -128,6 +181,22 @@ class Abilita
         $stmt = $this->conn->prepare('SELECT conoscenza_id FROM abilita_conoscenze WHERE abilita_id = :id');
         $stmt->execute(['id' => $this->id]);
         $this->conoscenze = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        // Load anni_corso
+        $stmt_anni = $this->conn->prepare('SELECT anno_corso FROM abilita_anni_corso WHERE abilita_id = :id ORDER BY anno_corso ASC');
+        $stmt_anni->execute(['id' => $this->id]);
+        $this->anni_corso = $stmt_anni->fetchAll(PDO::FETCH_COLUMN, 0);
+
+        // Load discipline
+        $stmt_disc = $this->conn->prepare('
+            SELECT d.nome
+            FROM abilita_discipline ad
+            JOIN discipline d ON ad.disciplina_id = d.id
+            WHERE ad.abilita_id = :id
+            ORDER BY d.nome ASC
+        ');
+        $stmt_disc->execute(['id' => $this->id]);
+        $this->discipline = $stmt_disc->fetchAll(PDO::FETCH_COLUMN, 0);
     }
 
     /**

--- a/src/AnniCorsoManager.php
+++ b/src/AnniCorsoManager.php
@@ -1,0 +1,128 @@
+<?php
+
+class AnniCorsoManager
+{
+    private $conn;
+
+    public function __construct($db)
+    {
+        $this->conn = $db;
+    }
+
+    /**
+     * Recalculates and updates all course year associations for every knowledge and skill.
+     * This method is expensive and should be called within a transaction when other data is being modified.
+     * @return bool True on success, false on failure.
+     */
+    public function updateAll()
+    {
+        try {
+            // No transaction here, assuming it's managed by the calling save() method.
+
+            // --- YEARS ---
+
+            // 1. Clear existing associations for years
+            $this->conn->exec('DELETE FROM competenza_anni_corso');
+            $this->conn->exec('DELETE FROM conoscenza_anni_corso');
+            $this->conn->exec('DELETE FROM abilita_anni_corso');
+
+            // 2. Recalculate and insert for Conoscenze (years)
+            $sql_conoscenze_anni = "
+                INSERT INTO conoscenza_anni_corso (conoscenza_id, anno_corso)
+                SELECT DISTINCT lc.conoscenza_id, m.anno_corso
+                FROM lezione_conoscenze lc
+                JOIN lessons l ON lc.lezione_id = l.id
+                JOIN udas u ON l.uda_id = u.id
+                JOIN modules m ON u.module_id = m.id
+                WHERE m.anno_corso IS NOT NULL
+                ON DUPLICATE KEY UPDATE conoscenza_id = VALUES(conoscenza_id), anno_corso = VALUES(anno_corso);
+            ";
+            $this->conn->exec($sql_conoscenze_anni);
+
+            // 3. Recalculate and insert for Abilità (years)
+            $sql_abilita_anni = "
+                INSERT INTO abilita_anni_corso (abilita_id, anno_corso)
+                SELECT DISTINCT la.abilita_id, m.anno_corso
+                FROM lezione_abilita la
+                JOIN lessons l ON la.lezione_id = l.id
+                JOIN udas u ON l.uda_id = u.id
+                JOIN modules m ON u.module_id = m.id
+                WHERE m.anno_corso IS NOT NULL
+                ON DUPLICATE KEY UPDATE abilita_id = VALUES(abilita_id), anno_corso = VALUES(anno_corso);
+            ";
+            $this->conn->exec($sql_abilita_anni);
+
+            // 4. Recalculate and insert for Competenze (years)
+            $sql_competenze_anni = "
+                INSERT INTO competenza_anni_corso (competenza_id, anno_corso)
+                SELECT DISTINCT competenza_id, anno_corso FROM (
+                    SELECT cc.competenza_id, cac.anno_corso
+                    FROM competenza_conoscenze cc
+                    JOIN conoscenza_anni_corso cac ON cc.conoscenza_id = cac.conoscenza_id
+                    UNION
+                    SELECT ca.competenza_id, aac.anno_corso
+                    FROM competenza_abilita ca
+                    JOIN abilita_anni_corso aac ON ca.abilita_id = aac.abilita_id
+                ) as anni_ereditati
+                ON DUPLICATE KEY UPDATE competenza_id = VALUES(competenza_id), anno_corso = VALUES(anno_corso);
+            ";
+            $this->conn->exec($sql_competenze_anni);
+
+            // --- DISCIPLINES ---
+
+            // 1. Clear existing associations for disciplines
+            $this->conn->exec('DELETE FROM competenza_discipline');
+            $this->conn->exec('DELETE FROM conoscenza_discipline');
+            $this->conn->exec('DELETE FROM abilita_discipline');
+
+            // 2. Recalculate and insert for Conoscenze (disciplines)
+            $sql_conoscenze_disc = "
+                INSERT INTO conoscenza_discipline (conoscenza_id, disciplina_id)
+                SELECT DISTINCT lc.conoscenza_id, m.disciplina_id
+                FROM lezione_conoscenze lc
+                JOIN lessons l ON lc.lezione_id = l.id
+                JOIN udas u ON l.uda_id = u.id
+                JOIN modules m ON u.module_id = m.id
+                WHERE m.disciplina_id IS NOT NULL
+                ON DUPLICATE KEY UPDATE conoscenza_id = VALUES(conoscenza_id), disciplina_id = VALUES(disciplina_id);
+            ";
+            $this->conn->exec($sql_conoscenze_disc);
+
+            // 3. Recalculate and insert for Abilità (disciplines)
+            $sql_abilita_disc = "
+                INSERT INTO abilita_discipline (abilita_id, disciplina_id)
+                SELECT DISTINCT la.abilita_id, m.disciplina_id
+                FROM lezione_abilita la
+                JOIN lessons l ON la.lezione_id = l.id
+                JOIN udas u ON l.uda_id = u.id
+                JOIN modules m ON u.module_id = m.id
+                WHERE m.disciplina_id IS NOT NULL
+                ON DUPLICATE KEY UPDATE abilita_id = VALUES(abilita_id), disciplina_id = VALUES(disciplina_id);
+            ";
+            $this->conn->exec($sql_abilita_disc);
+
+            // 4. Recalculate and insert for Competenze (disciplines)
+            $sql_competenze_disc = "
+                INSERT INTO competenza_discipline (competenza_id, disciplina_id)
+                SELECT DISTINCT competenza_id, disciplina_id FROM (
+                    SELECT cc.competenza_id, cd.disciplina_id
+                    FROM competenza_conoscenze cc
+                    JOIN conoscenza_discipline cd ON cc.conoscenza_id = cd.conoscenza_id
+                    UNION
+                    SELECT ca.competenza_id, ad.disciplina_id
+                    FROM competenza_abilita ca
+                    JOIN abilita_discipline ad ON ca.abilita_id = ad.abilita_id
+                ) as discipline_ereditate
+                ON DUPLICATE KEY UPDATE competenza_id = VALUES(competenza_id), disciplina_id = VALUES(disciplina_id);
+            ";
+            $this->conn->exec($sql_competenze_disc);
+
+
+            return true;
+        } catch (Exception $e) {
+            // In a real app, you would log the error message.
+            // error_log("AnniCorsoManager Error: " . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/AnniCorsoManager.php';
+
 class Module
 {
     private $conn;
@@ -87,7 +89,7 @@ class Module
     }
 
     /**
-     * Save the Module (insert or update).
+     * Save the Module (insert or update) and trigger the update of course years.
      *
      * @return bool|string True on success, error message string on failure.
      */
@@ -101,38 +103,49 @@ class Module
             $this->disciplina_id = null;
         }
 
-        if ($this->id) {
-            // Update existing Module
-            $sql = 'UPDATE modules SET name = :name, description = :description, disciplina_id = :disciplina_id, anno_corso = :anno_corso WHERE id = :id';
-            $params = [
-                'id' => $this->id,
-                'name' => $this->name,
-                'description' => $this->description,
-                'disciplina_id' => $this->disciplina_id,
-                'anno_corso' => $this->anno_corso,
-            ];
-        } else {
-            // Insert new Module
-            $sql = 'INSERT INTO modules (name, description, disciplina_id, anno_corso) VALUES (:name, :description, :disciplina_id, :anno_corso)';
-            $params = [
-                'name' => $this->name,
-                'description' => $this->description,
-                'disciplina_id' => $this->disciplina_id,
-                'anno_corso' => $this->anno_corso,
-            ];
-        }
+        try {
+            $this->conn->beginTransaction();
 
-        $stmt = $this->conn->prepare($sql);
-        $result = $stmt->execute($params);
+            if ($this->id) {
+                // Update existing Module
+                $sql = 'UPDATE modules SET name = :name, description = :description, disciplina_id = :disciplina_id, anno_corso = :anno_corso WHERE id = :id';
+                $params = [
+                    'id' => $this->id,
+                    'name' => $this->name,
+                    'description' => $this->description,
+                    'disciplina_id' => $this->disciplina_id,
+                    'anno_corso' => $this->anno_corso,
+                ];
+            } else {
+                // Insert new Module
+                $sql = 'INSERT INTO modules (name, description, disciplina_id, anno_corso) VALUES (:name, :description, :disciplina_id, :anno_corso)';
+                $params = [
+                    'name' => $this->name,
+                    'description' => $this->description,
+                    'disciplina_id' => $this->disciplina_id,
+                    'anno_corso' => $this->anno_corso,
+                ];
+            }
 
-        if ($result) {
+            $stmt = $this->conn->prepare($sql);
+            $stmt->execute($params);
+
             if (!$this->id) {
                 $this->id = $this->conn->lastInsertId();
             }
+
+            // After saving, trigger the course year recalculation
+            $anniCorsoManager = new AnniCorsoManager($this->conn);
+            if (!$anniCorsoManager->updateAll()) {
+                 throw new Exception("Failed to update course year associations.");
+            }
+
+            $this->conn->commit();
             return true;
-        } else {
-            $errorInfo = $stmt->errorInfo();
-            return "DB Error: " . ($errorInfo[2] ?? 'Unknown error');
+
+        } catch (Exception $e) {
+            $this->conn->rollBack();
+            return "DB Error: " . $e->getMessage();
         }
     }
 

--- a/src/Uda.php
+++ b/src/Uda.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/AnniCorsoManager.php';
+
 class Uda
 {
     private $conn;
@@ -9,6 +11,9 @@ class Uda
     public $name;
     public $description;
 
+    public $disciplina_nome;
+    public $anno_corso;
+
     public function __construct($db, $data = [])
     {
         $this->conn = $db;
@@ -16,6 +21,8 @@ class Uda
         $this->module_id = $data['module_id'] ?? null;
         $this->name = $data['name'] ?? '';
         $this->description = $data['description'] ?? '';
+        $this->disciplina_nome = $data['disciplina_nome'] ?? null;
+        $this->anno_corso = $data['anno_corso'] ?? null;
     }
 
     /**
@@ -25,7 +32,21 @@ class Uda
      */
     public function findAll()
     {
-        $stmt = $this->conn->prepare('SELECT * FROM udas ORDER BY name ASC');
+        $sql = "
+            SELECT
+                u.*,
+                d.nome AS disciplina_nome,
+                m.anno_corso
+            FROM
+                udas u
+            LEFT JOIN
+                modules m ON u.module_id = m.id
+            LEFT JOIN
+                discipline d ON m.disciplina_id = d.id
+            ORDER BY
+                u.name ASC
+        ";
+        $stmt = $this->conn->prepare($sql);
         $stmt->execute();
 
         $udaData = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -45,7 +66,21 @@ class Uda
      */
     public function findById($id)
     {
-        $stmt = $this->conn->prepare('SELECT * FROM udas WHERE id = :id');
+        $sql = "
+            SELECT
+                u.*,
+                d.nome AS disciplina_nome,
+                m.anno_corso
+            FROM
+                udas u
+            LEFT JOIN
+                modules m ON u.module_id = m.id
+            LEFT JOIN
+                discipline d ON m.disciplina_id = d.id
+            WHERE
+                u.id = :id
+        ";
+        $stmt = $this->conn->prepare($sql);
         $stmt->execute(['id' => $id]);
         $data = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -63,7 +98,23 @@ class Uda
      */
     public function findByModuleId($moduleId)
     {
-        $stmt = $this->conn->prepare('SELECT * FROM udas WHERE module_id = :module_id ORDER BY name ASC');
+        $sql = "
+            SELECT
+                u.*,
+                d.nome AS disciplina_nome,
+                m.anno_corso
+            FROM
+                udas u
+            LEFT JOIN
+                modules m ON u.module_id = m.id
+            LEFT JOIN
+                discipline d ON m.disciplina_id = d.id
+            WHERE
+                u.module_id = :module_id
+            ORDER BY
+                u.name ASC
+        ";
+        $stmt = $this->conn->prepare($sql);
         $stmt->execute(['module_id' => $moduleId]);
 
         $udaData = $stmt->fetchAll(PDO::FETCH_ASSOC);
@@ -76,42 +127,53 @@ class Uda
     }
 
     /**
-     * Save the UDA (insert or update).
+     * Save the UDA (insert or update) and trigger the update of course years.
      *
      * @return bool|string True on success, error message string on failure.
      */
     public function save()
     {
-        if ($this->id) {
-            // Update existing UDA
-            $sql = 'UPDATE udas SET module_id = :module_id, name = :name, description = :description WHERE id = :id';
-            $params = [
-                'id' => $this->id,
-                'module_id' => $this->module_id,
-                'name' => $this->name,
-                'description' => $this->description,
-            ];
-        } else {
-            // Insert new UDA
-            $sql = 'INSERT INTO udas (module_id, name, description) VALUES (:module_id, :name, :description)';
-            $params = [
-                'module_id' => $this->module_id,
-                'name' => $this->name,
-                'description' => $this->description,
-            ];
-        }
+        try {
+            $this->conn->beginTransaction();
 
-        $stmt = $this->conn->prepare($sql);
-        $result = $stmt->execute($params);
+            if ($this->id) {
+                // Update existing UDA
+                $sql = 'UPDATE udas SET module_id = :module_id, name = :name, description = :description WHERE id = :id';
+                $params = [
+                    'id' => $this->id,
+                    'module_id' => $this->module_id,
+                    'name' => $this->name,
+                    'description' => $this->description,
+                ];
+            } else {
+                // Insert new UDA
+                $sql = 'INSERT INTO udas (module_id, name, description) VALUES (:module_id, :name, :description)';
+                $params = [
+                    'module_id' => $this->module_id,
+                    'name' => $this->name,
+                    'description' => $this->description,
+                ];
+            }
 
-        if ($result) {
+            $stmt = $this->conn->prepare($sql);
+            $stmt->execute($params);
+
             if (!$this->id) {
                 $this->id = $this->conn->lastInsertId();
             }
+
+            // After saving, trigger the course year recalculation
+            $anniCorsoManager = new AnniCorsoManager($this->conn);
+            if (!$anniCorsoManager->updateAll()) {
+                throw new Exception("Failed to update course year associations.");
+            }
+
+            $this->conn->commit();
             return true;
-        } else {
-            $errorInfo = $stmt->errorInfo();
-            return "DB Error: " . ($errorInfo[2] ?? 'Unknown error');
+
+        } catch (Exception $e) {
+            $this->conn->rollBack();
+            return "DB Error: " . $e->getMessage();
         }
     }
 

--- a/udas/index.php
+++ b/udas/index.php
@@ -18,18 +18,23 @@ $page_title = 'Gestione UDA';
 $entity_name = 'UDA';
 $table_name = 'udas';
 $joins = [
-    'LEFT JOIN modules ON udas.module_id = modules.id'
+    'LEFT JOIN modules ON udas.module_id = modules.id',
+    'LEFT JOIN discipline ON modules.disciplina_id = discipline.id'
 ];
 $selects = [
     'udas.id as id',
     'udas.name as name',
     'udas.description as description',
-    'modules.name as module_name'
+    'modules.name as module_name',
+    'discipline.nome as disciplina_nome',
+    'modules.anno_corso as anno_corso'
 ];
 $columns = [
     'name' => 'Nome',
     'description' => 'Descrizione',
-    'module_name' => 'Modulo'
+    'module_name' => 'Modulo',
+    'disciplina_nome' => 'Disciplina',
+    'anno_corso' => 'Anno'
 ];
 
 // The "view" for a UDA is the list of lessons associated with it.

--- a/udas/view.php
+++ b/udas/view.php
@@ -32,8 +32,16 @@ $udas = $uda_manager->findByModuleId($module_id);
             <?php else: ?>
                 <?php foreach ($udas as $uda): ?>
                     <a href="../lessons/index.php?uda_id=<?php echo $uda->id; ?>" class="list-group-item list-group-item-action">
-                        <div class="d-flex w-100 justify-content-between">
+                        <div class="d-flex w-100 justify-content-between align-items-center">
                             <h5 class="mb-1"><?php echo htmlspecialchars($uda->name); ?></h5>
+                            <div>
+                                <?php if ($uda->anno_corso): ?>
+                                    <span class="badge bg-info me-1">Anno <?php echo htmlspecialchars($uda->anno_corso); ?></span>
+                                <?php endif; ?>
+                                <?php if ($uda->disciplina_nome): ?>
+                                    <span class="badge bg-primary"><?php echo htmlspecialchars($uda->disciplina_nome); ?></span>
+                                <?php endif; ?>
+                            </div>
                         </div>
                         <p class="mb-1"><?php echo htmlspecialchars($uda->description); ?></p>
                     </a>


### PR DESCRIPTION
This commit introduces a comprehensive system for calculating and displaying inherited data (course years and disciplines) across the application.

Key changes:
- Created `AnniCorsoManager` to handle the automatic recalculation of all inherited data.
- The inheritance logic follows the chain: Module -> UDA -> Lesson -> Conoscenza/Abilità -> Competenza
- Updated the database schema with new join tables for discipline and year inheritance.
- Modified the `save()` methods in `Module`, `Uda`, `Lesson`, and `Competenza` to trigger the recalculation manager, ensuring data is always in sync.
- Updated the `Conoscenza`, `Abilita`, `Competenza`, `Lesson`, and `Uda` models to efficiently load and provide the inherited data.
- Updated all `index.php` and `view.php` pages for these entities to display the inherited years and disciplines, using badges for clear visualization.
- Refactored the JavaScript table renderer to be more generic and reusable.
- Fixed a bug in `lessons/index.php` where the dynamic table was not correctly configured to fetch and display the inherited discipline.