### PR TITLE
feat: Add estimated time to modules and change year to dropdown

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -81,6 +81,7 @@ CREATE TABLE `modules` (
   `description` text,
   `disciplina_id` int(11) DEFAULT NULL,
   `anno_corso` tinyint(4) DEFAULT NULL,
+  `tempo_stimato` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `disciplina_id` (`disciplina_id`),
   CONSTRAINT `modules_ibfk_1` FOREIGN KEY (`disciplina_id`) REFERENCES `discipline` (`id`) ON DELETE SET NULL

--- a/modules/edit.php
+++ b/modules/edit.php
@@ -71,9 +71,20 @@ if (isset($_GET['id']) && !empty($_GET['id'])) {
                                 <?php endforeach; ?>
                             </select>
                         </div>
-                        <div class="col-md-6 mb-3">
+                        <div class="col-md-4 mb-3">
                             <label for="anno_corso" class="form-label">Anno di Corso</label>
-                            <input type="number" class="form-control" id="anno_corso" name="anno_corso" min="1" max="5" value="<?php echo htmlspecialchars($module->anno_corso ?? ''); ?>">
+                            <select class="form-select" id="anno_corso" name="anno_corso">
+                                <option value="">Tutti gli anni</option>
+                                <?php for ($i = 1; $i <= 5; $i++): ?>
+                                    <option value="<?php echo $i; ?>" <?php echo ($module->anno_corso == $i) ? 'selected' : ''; ?>>
+                                        <?php echo $i; ?>
+                                    </option>
+                                <?php endfor; ?>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="tempo_stimato" class="form-label">Tempo Stimato (ore)</label>
+                            <input type="number" class="form-control" id="tempo_stimato" name="tempo_stimato" min="0" value="<?php echo htmlspecialchars($module->tempo_stimato ?? ''); ?>">
                         </div>
                     </div>
 

--- a/src/Module.php
+++ b/src/Module.php
@@ -11,6 +11,7 @@ class Module
     public $description;
     public $disciplina_id;
     public $anno_corso;
+    public $tempo_stimato;
     public $disciplina_name;
 
     public function __construct($db, $data = [])
@@ -21,6 +22,7 @@ class Module
         $this->description = $data['description'] ?? '';
         $this->disciplina_id = $data['disciplina_id'] ?? null;
         $this->anno_corso = $data['anno_corso'] ?? null;
+        $this->tempo_stimato = $data['tempo_stimato'] ?? null;
         $this->disciplina_name = $data['disciplina_name'] ?? null;
     }
 
@@ -102,28 +104,33 @@ class Module
         if ($this->disciplina_id === '') {
             $this->disciplina_id = null;
         }
+        if ($this->tempo_stimato === '') {
+            $this->tempo_stimato = null;
+        }
 
         try {
             $this->conn->beginTransaction();
 
             if ($this->id) {
                 // Update existing Module
-                $sql = 'UPDATE modules SET name = :name, description = :description, disciplina_id = :disciplina_id, anno_corso = :anno_corso WHERE id = :id';
+                $sql = 'UPDATE modules SET name = :name, description = :description, disciplina_id = :disciplina_id, anno_corso = :anno_corso, tempo_stimato = :tempo_stimato WHERE id = :id';
                 $params = [
                     'id' => $this->id,
                     'name' => $this->name,
                     'description' => $this->description,
                     'disciplina_id' => $this->disciplina_id,
                     'anno_corso' => $this->anno_corso,
+                    'tempo_stimato' => $this->tempo_stimato,
                 ];
             } else {
                 // Insert new Module
-                $sql = 'INSERT INTO modules (name, description, disciplina_id, anno_corso) VALUES (:name, :description, :disciplina_id, :anno_corso)';
+                $sql = 'INSERT INTO modules (name, description, disciplina_id, anno_corso, tempo_stimato) VALUES (:name, :description, :disciplina_id, :anno_corso, :tempo_stimato)';
                 $params = [
                     'name' => $this->name,
                     'description' => $this->description,
                     'disciplina_id' => $this->disciplina_id,
                     'anno_corso' => $this->anno_corso,
+                    'tempo_stimato' => $this->tempo_stimato,
                 ];
             }
 

--- a/update_database.sql
+++ b/update_database.sql
@@ -32,3 +32,5 @@ CREATE TABLE `lezione_contenuti` (
   FOREIGN KEY (`lezione_id`) REFERENCES `lessons`(`id`) ON DELETE CASCADE,
   FOREIGN KEY (`contenuto_id`) REFERENCES `contenuti`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `modules` ADD `tempo_stimato` INT(11) DEFAULT NULL;


### PR DESCRIPTION
This commit introduces two new features to the modules section:

1.  An "estimated time" field (tempo_stimato) has been added to modules, measured in hours. This includes:
    - A new `tempo_stimato` column in the `modules` table.
    - Updates to the `Module` class to support the new field.
    - A new input field in the module edit form.

2.  The "year of course" (anno_corso) input in the module edit form has been converted from a number input to a dropdown menu. This provides a more user-friendly way to select the year, with options from 1 to 5 and a "not selected" option for all years.