### PR TITLE
Fix: Correctly handle multiple selections for module relationships

### DIFF
--- a/modules/save.php
+++ b/modules/save.php
@@ -33,6 +33,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $entity->abilita = $post_data['abilita'] ?? [];
     $entity->competenze = $post_data['competenze'] ?? [];
 
+    // Prevent the generic handler from overwriting these properties
+    unset($post_data['conoscenze'], $post_data['abilita'], $post_data['competenze']);
+
     // Include the generic handler
     require_once '../handlers/save_handler.php';
 } else {


### PR DESCRIPTION
In `modules/save.php`, the form data for 'conoscenze', 'abilita', and 'competenze' was being correctly assigned to the entity. However, the generic `save_handler.php` would then iterate over the raw POST data and overwrite these arrays.

This change prevents the overwriting by unsetting these keys from the `$post_data` array after they have been processed, ensuring the many-to-many relationships are saved correctly. The frontend in `modules/edit.php` already supported multiple selections.