### PR TITLE
Feat: Replace multi-select with checkboxes for relationships

### DIFF
--- a/modules/edit.php
+++ b/modules/edit.php
@@ -100,33 +100,42 @@ if (isset($_GET['id']) && !empty($_GET['id'])) {
                     <div class="row mt-4">
                         <div class="col-md-4 mb-3">
                             <label for="conoscenze" class="form-label">Conoscenze</label>
-                            <select multiple class="form-control" id="conoscenze" name="conoscenze[]" style="height: 200px;">
+                            <div class="form-control" style="height: 200px; overflow-y: auto;">
                                 <?php foreach ($all_conoscenze as $item): ?>
-                                    <option value="<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->conoscenze) ? 'selected' : ''; ?>>
-                                        <?php echo htmlspecialchars($item->nome); ?>
-                                    </option>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="conoscenze[]" value="<?php echo $item->id; ?>" id="conoscenza_<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->conoscenze) ? 'checked' : ''; ?>>
+                                        <label class="form-check-label" for="conoscenza_<?php echo $item->id; ?>">
+                                            <?php echo htmlspecialchars($item->nome); ?>
+                                        </label>
+                                    </div>
                                 <?php endforeach; ?>
-                            </select>
+                            </div>
                         </div>
                         <div class="col-md-4 mb-3">
                             <label for="abilita" class="form-label">Abilità</label>
-                            <select multiple class="form-control" id="abilita" name="abilita[]" style="height: 200px;">
+                            <div class="form-control" style="height: 200px; overflow-y: auto;">
                                 <?php foreach ($all_abilita as $item): ?>
-                                    <option value="<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->abilita) ? 'selected' : ''; ?>>
-                                        <?php echo htmlspecialchars($item->nome); ?>
-                                    </option>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="abilita[]" value="<?php echo $item->id; ?>" id="abilita_<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->abilita) ? 'checked' : ''; ?>>
+                                        <label class="form-check-label" for="abilita_<?php echo $item->id; ?>">
+                                            <?php echo htmlspecialchars($item->nome); ?>
+                                        </label>
+                                    </div>
                                 <?php endforeach; ?>
-                            </select>
+                            </div>
                         </div>
                         <div class="col-md-4 mb-3">
                             <label for="competenze" class="form-label">Competenze</label>
-                            <select multiple class="form-control" id="competenze" name="competenze[]" style="height: 200px;">
+                            <div class="form-control" style="height: 200px; overflow-y: auto;">
                                 <?php foreach ($all_competenze as $item): ?>
-                                    <option value="<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->competenze) ? 'selected' : ''; ?>>
-                                        <?php echo htmlspecialchars($item->nome); ?>
-                                    </option>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="competenze[]" value="<?php echo $item->id; ?>" id="competenza_<?php echo $item->id; ?>" <?php echo in_array($item->id, $module->competenze) ? 'checked' : ''; ?>>
+                                        <label class="form-check-label" for="competenza_<?php echo $item->id; ?>">
+                                            <?php echo htmlspecialchars($item->nome); ?>
+                                        </label>
+                                    </div>
                                 <?php endforeach; ?>
-                            </select>
+                            </div>
                         </div>
                     </div>
 

--- a/modules/save.php
+++ b/modules/save.php
@@ -33,6 +33,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $entity->abilita = $post_data['abilita'] ?? [];
     $entity->competenze = $post_data['competenze'] ?? [];
 
+    // Prevent the generic handler from overwriting these properties
+    unset($post_data['conoscenze'], $post_data['abilita'], $post_data['competenze']);
+
     // Include the generic handler
     require_once '../handlers/save_handler.php';
 } else {


### PR DESCRIPTION
Based on user feedback, the multi-select dropdowns for 'conoscenze', 'abilita', and 'competenze' have been replaced with lists of checkboxes.

This provides a more intuitive user experience, as it does not require holding a key to select multiple items.

The UI has been updated in `modules/edit.php` to render scrollable lists of checkboxes using Bootstrap's form-check styling. The backend logic in `modules/save.php` already correctly handles array data from forms, so it continues to work with the checkbox submissions.