### PR TITLE
Feat: Add 'origine' field to Conoscenze, Abilita, and Competenze

### DIFF
--- a/abilita/edit.php
+++ b/abilita/edit.php
@@ -41,6 +41,17 @@ $form_fields = [
             'cognitiva' => 'Cognitiva',
             'tecnico/pratica' => 'Tecnico/Pratica'
         ]
+    ],
+    'origine' => [
+        'label' => 'Origine',
+        'type' => 'select',
+        'required' => true,
+        'options' => [
+            'dipartimento' => 'Dipartimento',
+            'ministeriali' => 'Ministeriali',
+            'docente' => 'Docente',
+            'altro' => 'Altro'
+        ]
     ]
 ];
 

--- a/abilita/index.php
+++ b/abilita/index.php
@@ -19,6 +19,7 @@ $entity_name = 'Abilità';
 $table_name = 'abilita';
 $columns = [
     'nome' => 'Nome',
+    'origine' => 'Origine',
     'tipo' => 'Tipo',
     'anni_corso' => 'Anni di Corso',
     'discipline' => 'Discipline'

--- a/competenze/edit.php
+++ b/competenze/edit.php
@@ -42,6 +42,17 @@ $form_fields = [
         'options' => $tipologie_options,
         'required' => true,
         'default_option' => 'Seleziona una tipologia...'
+    ],
+    'origine' => [
+        'label' => 'Origine',
+        'type' => 'select',
+        'required' => true,
+        'options' => [
+            'dipartimento' => 'Dipartimento',
+            'ministeriali' => 'Ministeriali',
+            'docente' => 'Docente',
+            'altro' => 'Altro'
+        ]
     ]
 ];
 

--- a/competenze/index.php
+++ b/competenze/index.php
@@ -24,10 +24,12 @@ $joins = [
 $selects = [
     'competenze.id as id',
     'competenze.nome as nome',
+    'competenze.origine as origine',
     'tipologie_competenze.nome as tipologia'
 ];
 $columns = [
     'nome' => 'Nome',
+    'origine' => 'Origine',
     'tipologia' => 'Tipologia',
     'anni_corso' => 'Anni di Corso',
     'discipline' => 'Discipline'

--- a/conoscenze/edit.php
+++ b/conoscenze/edit.php
@@ -10,39 +10,37 @@ if ($_SESSION['role'] !== 'teacher') {
     exit;
 }
 
-// Get the database connection
+// Configuration for the generic edit handler
 $db = Database::getInstance()->getConnection();
+$manager = new Conoscenza($db);
 
-$conoscenza_manager = new Conoscenza($db);
-$conoscenza = null;
+$entity = null;
 if (isset($_GET['id'])) {
-    $conoscenza = $conoscenza_manager->findById($_GET['id']);
+    $entity = $manager->findById((int)$_GET['id']);
 } else {
-    $conoscenza = new Conoscenza($db);
+    $entity = new Conoscenza($db);
 }
 
-$pageTitle = $conoscenza ? 'Modifica Conoscenza' : 'Crea Nuova Conoscenza';
-$formAction = 'save.php';
+$page_title = $entity->id ? 'Modifica Conoscenza' : 'Crea Nuova Conoscenza';
+$form_action = 'save.php';
+
+$form_fields = [
+    'nome' => ['label' => 'Nome', 'type' => 'text', 'required' => true],
+    'descrizione' => ['label' => 'Descrizione', 'type' => 'textarea'],
+    'origine' => [
+        'label' => 'Origine',
+        'type' => 'select',
+        'required' => true,
+        'options' => [
+            'dipartimento' => 'Dipartimento',
+            'ministeriali' => 'Ministeriali',
+            'docente' => 'Docente',
+            'altro' => 'Altro'
+        ]
+    ]
+];
+
+// Include the generic handler
+require_once '../handlers/edit_handler.php';
 ?>
-    <div class="container mt-5">
-        <h2><?php echo $pageTitle; ?></h2>
-        <form action="<?php echo $formAction; ?>" method="post">
-            <?php if ($conoscenza && $conoscenza->id): ?>
-                <input type="hidden" name="id" value="<?php echo $conoscenza->id; ?>">
-            <?php endif; ?>
-
-            <div class="form-group">
-                <label for="nome">Nome</label>
-                <input type="text" class="form-control" id="nome" name="nome" value="<?php echo htmlspecialchars($conoscenza->nome ?? ''); ?>" required>
-            </div>
-
-            <div class="form-group">
-                <label for="descrizione">Descrizione</label>
-                <textarea class="form-control" id="descrizione" name="descrizione" rows="3"><?php echo htmlspecialchars($conoscenza->descrizione ?? ''); ?></textarea>
-            </div>
-
-            <button type="submit" class="btn btn-primary">Salva</button>
-            <a href="index.php" class="btn btn-secondary">Annulla</a>
-        </form>
-    </div>
 <?php include '../footer.php'; ?>

--- a/conoscenze/index.php
+++ b/conoscenze/index.php
@@ -19,6 +19,7 @@ $entity_name = 'Conoscenza';
 $table_name = 'conoscenze';
 $columns = [
     'nome' => 'Nome',
+    'origine' => 'Origine',
     'anni_corso' => 'Anni di Corso',
     'discipline' => 'Discipline'
 ];

--- a/src/Abilita.php
+++ b/src/Abilita.php
@@ -8,6 +8,7 @@ class Abilita
     public $nome;
     public $descrizione;
     public $tipo;
+    public $origine;
 
     // Related data
     public $anni_corso;
@@ -20,6 +21,7 @@ class Abilita
         $this->nome = $data['nome'] ?? '';
         $this->descrizione = $data['descrizione'] ?? '';
         $this->tipo = $data['tipo'] ?? 'cognitiva'; // Default value
+        $this->origine = $data['origine'] ?? 'altro';
 
         // These will be loaded separately
         $this->anni_corso = $data['anni_corso'] ?? [];
@@ -124,19 +126,21 @@ class Abilita
             $this->conn->beginTransaction();
 
             if ($this->id) {
-                $stmt = $this->conn->prepare('UPDATE abilita SET nome = :nome, descrizione = :descrizione, tipo = :tipo WHERE id = :id');
+                $stmt = $this->conn->prepare('UPDATE abilita SET nome = :nome, descrizione = :descrizione, tipo = :tipo, origine = :origine WHERE id = :id');
                 $params = [
                     'nome' => $this->nome,
                     'descrizione' => $this->descrizione,
                     'tipo' => $this->tipo,
+                    'origine' => $this->origine,
                     'id' => $this->id
                 ];
             } else {
-                $stmt = $this->conn->prepare('INSERT INTO abilita (nome, descrizione, tipo) VALUES (:nome, :descrizione, :tipo)');
+                $stmt = $this->conn->prepare('INSERT INTO abilita (nome, descrizione, tipo, origine) VALUES (:nome, :descrizione, :tipo, :origine)');
                 $params = [
                     'nome' => $this->nome,
                     'descrizione' => $this->descrizione,
-                    'tipo' => $this->tipo
+                    'tipo' => $this->tipo,
+                    'origine' => $this->origine
                 ];
             }
 

--- a/src/Competenza.php
+++ b/src/Competenza.php
@@ -10,6 +10,7 @@ class Competenza
     public $nome;
     public $descrizione;
     public $tipologia_id;
+    public $origine;
 
     // Related data
     public $anni_corso;
@@ -22,6 +23,7 @@ class Competenza
         $this->nome = $data['nome'] ?? '';
         $this->descrizione = $data['descrizione'] ?? '';
         $this->tipologia_id = $data['tipologia_id'] ?? null;
+        $this->origine = $data['origine'] ?? 'altro';
 
         // These will be loaded separately if not provided
         $this->anni_corso = $data['anni_corso'] ?? [];
@@ -126,19 +128,21 @@ class Competenza
             $this->conn->beginTransaction();
 
             if ($this->id) {
-                $stmt = $this->conn->prepare('UPDATE competenze SET nome = :nome, descrizione = :descrizione, tipologia_id = :tipologia_id WHERE id = :id');
+                $stmt = $this->conn->prepare('UPDATE competenze SET nome = :nome, descrizione = :descrizione, tipologia_id = :tipologia_id, origine = :origine WHERE id = :id');
                 $params = [
                     'nome' => $this->nome,
                     'descrizione' => $this->descrizione,
                     'tipologia_id' => $this->tipologia_id,
+                    'origine' => $this->origine,
                     'id' => $this->id
                 ];
             } else {
-                $stmt = $this->conn->prepare('INSERT INTO competenze (nome, descrizione, tipologia_id) VALUES (:nome, :descrizione, :tipologia_id)');
+                $stmt = $this->conn->prepare('INSERT INTO competenze (nome, descrizione, tipologia_id, origine) VALUES (:nome, :descrizione, :tipologia_id, :origine)');
                 $params = [
                     'nome' => $this->nome,
                     'descrizione' => $this->descrizione,
-                    'tipologia_id' => $this->tipologia_id
+                    'tipologia_id' => $this->tipologia_id,
+                    'origine' => $this->origine
                 ];
             }
 

--- a/src/Conoscenza.php
+++ b/src/Conoscenza.php
@@ -7,6 +7,7 @@ class Conoscenza
     public $id;
     public $nome;
     public $descrizione;
+    public $origine;
 
     public $anni_corso;
     public $discipline;
@@ -17,6 +18,7 @@ class Conoscenza
         $this->id = $data['id'] ?? null;
         $this->nome = $data['nome'] ?? '';
         $this->descrizione = $data['descrizione'] ?? '';
+        $this->origine = $data['origine'] ?? 'altro';
 
         $this->anni_corso = $data['anni_corso'] ?? [];
         $this->discipline = $data['discipline'] ?? [];
@@ -147,11 +149,11 @@ class Conoscenza
             $this->conn->beginTransaction();
 
             if ($this->id) {
-                $stmt = $this->conn->prepare('UPDATE conoscenze SET nome = :nome, descrizione = :descrizione WHERE id = :id');
-                $params = ['nome' => $this->nome, 'descrizione' => $this->descrizione, 'id' => $this->id];
+                $stmt = $this->conn->prepare('UPDATE conoscenze SET nome = :nome, descrizione = :descrizione, origine = :origine WHERE id = :id');
+                $params = ['nome' => $this->nome, 'descrizione' => $this->descrizione, 'origine' => $this->origine, 'id' => $this->id];
             } else {
-                $stmt = $this->conn->prepare('INSERT INTO conoscenze (nome, descrizione) VALUES (:nome, :descrizione)');
-                $params = ['nome' => $this->nome, 'descrizione' => $this->descrizione];
+                $stmt = $this->conn->prepare('INSERT INTO conoscenze (nome, descrizione, origine) VALUES (:nome, :descrizione, :origine)');
+                $params = ['nome' => $this->nome, 'descrizione' => $this->descrizione, 'origine' => $this->origine];
             }
 
             $stmt->execute($params);


### PR DESCRIPTION
This commit implements a new mandatory field, 'origine', for the Conoscenze, Abilita, and Competenze entities.

The 'origine' field is an ENUM with the allowed values: 'dipartimento', 'ministeriali', 'docente', 'altro'.

Changes include:
- Updating the entity classes in `src/` to add the `origine` property.
- Modifying the `save()` methods to include the new field in database operations.
- Adding the 'origine' field as a required dropdown in the `edit.php` forms for all three entities.
- Adding an 'Origine' column to the `index.php` list views for all three entities.
- Refactoring `conoscenze/edit.php` to use the generic form handler for consistency.