### PR TITLE
feat: Add public and private document management pages

### DIFF
--- a/documenti/admin.php
+++ b/documenti/admin.php
@@ -1,0 +1,53 @@
+<?php
+require_once '../header.php';
+require_once '../src/Database.php';
+require_once '../src/Documento.php';
+
+$db = Database::getInstance()->getConnection();
+$documento = new Documento($db);
+$stmt = $documento->readAll();
+?>
+
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h4>Gestione Documenti</h4>
+            <a href="upload.php" class="btn btn-primary float-end">Carica Nuovo Documento</a>
+        </div>
+        <div class="card-body">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Nome File</th>
+                        <th>Tipo</th>
+                        <th>Dimensione</th>
+                        <th>Argomento</th>
+                        <th>Descrizione</th>
+                        <th>Data Caricamento</th>
+                        <th>Azioni</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) : ?>
+                        <tr>
+                            <td><?php echo htmlspecialchars($row['filename']); ?></td>
+                            <td><?php echo htmlspecialchars($row['file_type']); ?></td>
+                            <td><?php echo htmlspecialchars($row['size']); ?> bytes</td>
+                            <td><?php echo htmlspecialchars($row['topic']); ?></td>
+                            <td><?php echo htmlspecialchars($row['description']); ?></td>
+                            <td><?php echo htmlspecialchars($row['upload_date']); ?></td>
+                            <td>
+                                <a href="download.php?id=<?php echo $row['id']; ?>" class="btn btn-success btn-sm">Download</a>
+                                <a href="delete.php?id=<?php echo $row['id']; ?>" class="btn btn-danger btn-sm">Elimina</a>
+                            </td>
+                        </tr>
+                    <?php endwhile; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<?php
+require_once '../footer.php';
+?>

--- a/documenti/delete.php
+++ b/documenti/delete.php
@@ -1,0 +1,35 @@
+<?php
+session_start();
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
+    exit("Accesso non autorizzato.");
+}
+
+if (isset($_GET['id'])) {
+    require_once '../src/Database.php';
+    require_once '../src/Documento.php';
+
+    $db = Database::getInstance()->getConnection();
+    $documento = new Documento($db);
+    $documento->id = $_GET['id'];
+    $documento->readOne();
+
+    if ($documento->filename) {
+        $file_path = '../uploads/' . $documento->filename;
+
+        if (file_exists($file_path)) {
+            unlink($file_path);
+        }
+
+        if ($documento->delete()) {
+            header('Location: admin.php');
+            exit();
+        } else {
+            echo 'Errore nella cancellazione del documento dal database.';
+        }
+    } else {
+        echo 'Documento non trovato.';
+    }
+} else {
+    echo 'ID non specificato.';
+}
+?>

--- a/documenti/download.php
+++ b/documenti/download.php
@@ -1,0 +1,33 @@
+<?php
+if (isset($_GET['id'])) {
+    require_once '../src/Database.php';
+    require_once '../src/Documento.php';
+
+    $db = Database::getInstance()->getConnection();
+    $documento = new Documento($db);
+    $documento->id = $_GET['id'];
+    $documento->readOne();
+
+    if ($documento->filename) {
+        $file_path = '../uploads/' . $documento->filename;
+
+        if (file_exists($file_path)) {
+            header('Content-Description: File Transfer');
+            header('Content-Type: application/octet-stream');
+            header('Content-Disposition: attachment; filename="' . basename($file_path) . '"');
+            header('Expires: 0');
+            header('Cache-Control: must-revalidate');
+            header('Pragma: public');
+            header('Content-Length: ' . filesize($file_path));
+            readfile($file_path);
+            exit;
+        } else {
+            echo 'File non trovato.';
+        }
+    } else {
+        echo 'Documento non trovato.';
+    }
+} else {
+    echo 'ID non specificato.';
+}
+?>

--- a/documenti/index.php
+++ b/documenti/index.php
@@ -1,0 +1,57 @@
+<?php
+require_once '../src/Database.php';
+require_once '../src/Documento.php';
+
+$db = Database::getInstance()->getConnection();
+$documento = new Documento($db);
+$stmt = $documento->readAll();
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Elenco Documenti</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body>
+    <div class="container mt-4">
+        <div class="card">
+            <div class="card-header">
+                <h4>Elenco Documenti</h4>
+            </div>
+            <div class="card-body">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Nome File</th>
+                            <th>Tipo</th>
+                            <th>Dimensione</th>
+                            <th>Argomento</th>
+                            <th>Descrizione</th>
+                            <th>Data Caricamento</th>
+                            <th>Azioni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) : ?>
+                            <tr>
+                                <td><?php echo htmlspecialchars($row['filename']); ?></td>
+                                <td><?php echo htmlspecialchars($row['file_type']); ?></td>
+                                <td><?php echo htmlspecialchars($row['size']); ?> bytes</td>
+                                <td><?php echo htmlspecialchars($row['topic']); ?></td>
+                                <td><?php echo htmlspecialchars($row['description']); ?></td>
+                                <td><?php echo htmlspecialchars($row['upload_date']); ?></td>
+                                <td>
+                                    <a href="download.php?id=<?php echo $row['id']; ?>" class="btn btn-success btn-sm">Download</a>
+                                </td>
+                            </tr>
+                        <?php endwhile; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/documenti/save.php
+++ b/documenti/save.php
@@ -1,0 +1,35 @@
+<?php
+session_start();
+if (!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true) {
+    exit("Accesso non autorizzato.");
+}
+
+require_once '../src/Database.php';
+require_once '../src/Documento.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $db = Database::getInstance()->getConnection();
+    $documento = new Documento($db);
+
+    $upload_dir = '../uploads/';
+    $file_name = uniqid() . '-' . basename($_FILES['file']['name']);
+    $upload_file = $upload_dir . $file_name;
+
+    if (move_uploaded_file($_FILES['file']['tmp_name'], $upload_file)) {
+        $documento->filename = $file_name;
+        $documento->file_type = $_FILES['file']['type'];
+        $documento->size = $_FILES['file']['size'];
+        $documento->topic = $_POST['topic'];
+        $documento->description = $_POST['description'];
+
+        if ($documento->create()) {
+            header('Location: admin.php');
+            exit();
+        } else {
+            echo 'Errore nel salvataggio del documento nel database.';
+        }
+    } else {
+        echo 'Errore nel caricamento del file.';
+    }
+}
+?>

--- a/documenti/upload.php
+++ b/documenti/upload.php
@@ -1,0 +1,33 @@
+<?php
+require_once '../header.php';
+?>
+
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h4>Carica Nuovo Documento</h4>
+        </div>
+        <div class="card-body">
+            <form action="save.php" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <label for="file" class="form-label">Seleziona File</label>
+                    <input type="file" class="form-control" id="file" name="file" required>
+                </div>
+                <div class="mb-3">
+                    <label for="topic" class="form-label">Argomento</label>
+                    <input type="text" class="form-control" id="topic" name="topic" required>
+                </div>
+                <div class="mb-3">
+                    <label for="description" class="form-label">Descrizione</label>
+                    <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary">Carica</button>
+                <a href="index.php" class="btn btn-secondary">Annulla</a>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php
+require_once '../footer.php';
+?>

--- a/header.php
+++ b/header.php
@@ -51,6 +51,7 @@ function is_active($path) {
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item"><a class="nav-link <?php echo is_active('/dashboard.php'); ?>" href="/dashboard.php"><i class="fas fa-tachometer-alt"></i> Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link <?php echo is_active('/documenti/admin.php'); ?>" href="/documenti/admin.php"><i class="fas fa-file-alt"></i> Documenti</a></li>
 
                     <!-- Programmazione Dropdown -->
                     <li class="nav-item dropdown">

--- a/src/Documento.php
+++ b/src/Documento.php
@@ -1,0 +1,83 @@
+<?php
+
+class Documento
+{
+    private $conn;
+    private $table_name = "files";
+
+    public $id;
+    public $filename;
+    public $file_type;
+    public $size;
+    public $topic;
+    public $description;
+    public $upload_date;
+
+    public function __construct($db)
+    {
+        $this->conn = $db;
+    }
+
+    public function create()
+    {
+        $query = "INSERT INTO " . $this->table_name . " SET filename=:filename, file_type=:file_type, size=:size, topic=:topic, description=:description";
+        $stmt = $this->conn->prepare($query);
+
+        $this->filename = htmlspecialchars(strip_tags($this->filename));
+        $this->file_type = htmlspecialchars(strip_tags($this->file_type));
+        $this->size = htmlspecialchars(strip_tags($this->size));
+        $this->topic = htmlspecialchars(strip_tags($this->topic));
+        $this->description = htmlspecialchars(strip_tags($this->description));
+
+        $stmt->bindParam(":filename", $this->filename);
+        $stmt->bindParam(":file_type", $this->file_type);
+        $stmt->bindParam(":size", $this->size);
+        $stmt->bindParam(":topic", $this->topic);
+        $stmt->bindParam(":description", $this->description);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function readAll()
+    {
+        $query = "SELECT * FROM " . $this->table_name . " ORDER BY upload_date DESC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    public function readOne()
+    {
+        $query = "SELECT * FROM " . $this->table_name . " WHERE id = ? LIMIT 0,1";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $this->id);
+        $stmt->execute();
+
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        $this->filename = $row['filename'];
+        $this->file_type = $row['file_type'];
+        $this->size = $row['size'];
+        $this->topic = $row['topic'];
+        $this->description = $row['description'];
+        $this->upload_date = $row['upload_date'];
+    }
+
+    public function delete()
+    {
+        $query = "DELETE FROM " . $this->table_name . " WHERE id = ?";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $this->id);
+
+        if ($stmt->execute()) {
+            return true;
+        }
+
+        return false;
+    }
+}
+?>

--- a/update_database.sql
+++ b/update_database.sql
@@ -1,36 +1,14 @@
--- Tabella per i contenuti
-CREATE TABLE `contenuti` (
-  `id` INT(11) NOT NULL AUTO_INCREMENT,
-  `nome` VARCHAR(255) NOT NULL,
-  `descrizione` TEXT,
+--
+-- Table structure for table `files`
+--
+
+CREATE TABLE `files` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `filename` varchar(255) NOT NULL,
+  `file_type` varchar(100) NOT NULL,
+  `size` int(11) NOT NULL,
+  `topic` varchar(255) DEFAULT NULL,
+  `description` text,
+  `upload_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- Relazione Contenuti -> Conoscenze (N a N)
-CREATE TABLE `contenuto_conoscenze` (
-  `contenuto_id` INT(11) NOT NULL,
-  `conoscenza_id` INT(11) NOT NULL,
-  PRIMARY KEY (`contenuto_id`, `conoscenza_id`),
-  FOREIGN KEY (`contenuto_id`) REFERENCES `contenuti`(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`conoscenza_id`) REFERENCES `conoscenze`(`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- Relazione Contenuti -> Abilità (N a N)
-CREATE TABLE `contenuto_abilita` (
-  `contenuto_id` INT(11) NOT NULL,
-  `abilita_id` INT(11) NOT NULL,
-  PRIMARY KEY (`contenuto_id`, `abilita_id`),
-  FOREIGN KEY (`contenuto_id`) REFERENCES `contenuti`(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`abilita_id`) REFERENCES `abilita`(`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- Relazione Lezioni -> Contenuti (N a N)
-CREATE TABLE `lezione_contenuti` (
-  `lezione_id` INT(11) NOT NULL,
-  `contenuto_id` INT(11) NOT NULL,
-  PRIMARY KEY (`lezione_id`, `contenuto_id`),
-  FOREIGN KEY (`lezione_id`) REFERENCES `lessons`(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`contenuto_id`) REFERENCES `contenuti`(`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-ALTER TABLE `modules` ADD `tempo_stimato` INT(11) DEFAULT NULL;


### PR DESCRIPTION
This commit updates the document management system to provide separate public and private pages.

- The file list at `documenti/index.php` is now public and does not require login. It only shows the file list and download links.
- A new admin page at `documenti/admin.php` is available for logged-in users to manage documents (upload, delete).
- The navigation link for "Documenti" now points to the admin page.
- The `save.php` and `delete.php` scripts are now secured to only allow access to logged-in users.